### PR TITLE
Fix Connection, Network, Server and PresenterNetwork To-Dos

### DIFF
--- a/include/cloysterhpc/connection.h
+++ b/include/cloysterhpc/connection.h
@@ -51,8 +51,6 @@ private:
 public:
     Connection() = delete;
     explicit Connection(Network* network);
-    Connection(
-        Network* network, const std::string& interface, const std::string& ip);
     Connection(Network* network, std::optional<std::string_view> interface,
         std::optional<std::string_view> mac, const std::string& ip);
 

--- a/include/cloysterhpc/presenter/PresenterNetwork.h
+++ b/include/cloysterhpc/presenter/PresenterNetwork.h
@@ -26,11 +26,15 @@ private:
     struct Messages {
         static constexpr const char* title = "Network Settings";
 
-        // TODO: Find a way to express which interface you are dealing with:
-        //       "Select your <external> network interface", for example.
         struct Interface {
-            static constexpr const char* question
-                = "Select your network interface";
+            static std::string formatQuestion(
+                Network::Type type, Network::Profile profile)
+            {
+                return fmt::format("Select your {} ({}) network interface",
+                    magic_enum::enum_name(profile),
+                    magic_enum::enum_name(type));
+            }
+
             static constexpr const char* help
                 = Presenter::Messages::Placeholder::help;
         };
@@ -65,7 +69,10 @@ private:
     template <typename T>
     std::string networkInterfaceSelection(const T& interfaces)
     {
-        return m_view->listMenu(Messages::title, Messages::Interface::question,
+        return m_view->listMenu(Messages::title,
+            Messages::Interface::formatQuestion(
+                m_network->getType(), m_network->getProfile())
+                .c_str(),
             interfaces, Messages::Interface::help);
     }
 

--- a/include/cloysterhpc/server.h
+++ b/include/cloysterhpc/server.h
@@ -26,7 +26,6 @@ protected:
     std::string m_fqdn; // TODO: Remove?
 
 protected:
-    Server() = default;
     Server(std::string_view hostname, OS& os, CPU& cpu,
         std::list<Connection>&& connections,
         std::optional<BMC> bmc = std::nullopt);
@@ -62,6 +61,7 @@ public:
     void setBMC(const BMC& bmc);
 
     virtual ~Server() = default;
+    Server() = default;
 };
 
 #endif // CLOYSTERHPC_SERVER_H_

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -149,8 +149,7 @@ void Connection::setMAC(std::string_view mac)
         R"regex(^
     ([0-9A-Fa-f]{2}[:-]){5}        # Matches MAC address with colons or hyphens
     ([0-9A-Fa-f]{2})|              # Or
-    ([0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4})  # Matches IPv6 format
-    |([0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4}  # Matches Cisco MAC format
+    ([0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4}  # Matches Cisco MAC format
     $)regex");
 
     // regex_match cannot work with std::string_view

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -123,7 +123,7 @@ std::vector<std::string> Connection::fetchInterfaces()
         for (const auto& name : interfaces) {
             if (std::strcmp(ifa->ifa_name, name.c_str()) == 0) {
                 duplicate = true;
-                break;
+                continue;
             }
         }
 
@@ -144,6 +144,7 @@ void Connection::setMAC(std::string_view mac)
     if ((mac.size() != 12) && (mac.size() != 14) && (mac.size() != 17))
         throw std::runtime_error("Invalid MAC address size");
 
+    // This pattern validates whether an MAC address is valid or not.
     const std::regex pattern(
         R"regex(^
     ([0-9A-Fa-f]{2}[:-]){5}        # Matches MAC address with colons or hyphens

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -119,18 +119,15 @@ std::vector<std::string> Connection::fetchInterfaces()
         if (std::strcmp(ifa->ifa_name, "lo") == 0)
             continue;
 
-        bool duplicate = false;
-        for (const auto& name : interfaces) {
-            if (std::strcmp(ifa->ifa_name, name.c_str()) == 0) {
-                duplicate = true;
-                continue;
-            }
-        }
-
-        if (!duplicate) {
-            interfaces.emplace_back(ifa->ifa_name);
-        }
+        interfaces.emplace_back(ifa->ifa_name);
     }
+
+    // TODO: It must have a better way to remove duplicates instead of creating
+    //       a set to filter out them. Perhaps changing the return type?
+    std::set<std::string> aux(interfaces.begin(), interfaces.end());
+    interfaces.clear();
+    interfaces.reserve(aux.size());
+    interfaces.assign(aux.begin(), aux.end());
 
     return interfaces;
 }
@@ -147,9 +144,8 @@ void Connection::setMAC(std::string_view mac)
     // This pattern validates whether an MAC address is valid or not.
     const std::regex pattern(
         R"regex(^
-    ([0-9A-Fa-f]{2}[:-]){5}        # Matches MAC address with colons or hyphens
-    ([0-9A-Fa-f]{2})|              # Or
-    ([0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4}  # Matches Cisco MAC format
+    ([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})|  # Matches MAC address with colons or hyphens or
+    ([0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4}       # Matches Cisco MAC format
     $)regex");
 
     // regex_match cannot work with std::string_view

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -144,11 +144,13 @@ void Connection::setMAC(std::string_view mac)
     if ((mac.size() != 12) && (mac.size() != 14) && (mac.size() != 17))
         throw std::runtime_error("Invalid MAC address size");
 
-    // TODO: Make it easier to read and consider the Cisco MAC identifier
-    const std::regex pattern("^([0-9A-Fa-f]{2}[:-]){5}"
-                             "([0-9A-Fa-f]{2})|([0-9a-"
-                             "fA-F]{4}\\.[0-9a-fA-F]"
-                             "{4}\\.[0-9a-fA-F]{4})$");
+    const std::regex pattern(
+        R"regex(^
+    ([0-9A-Fa-f]{2}[:-]){5}        # Matches MAC address with colons or hyphens
+    ([0-9A-Fa-f]{2})|              # Or
+    ([0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4})  # Matches IPv6 format
+    |([0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4}  # Matches Cisco MAC format
+    $)regex");
 
     // regex_match cannot work with std::string_view
     if (std::string tempString { mac }; regex_match(tempString, pattern))

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -309,3 +309,78 @@ void Connection::dumpConnection() const
     LOG_DEBUG("===================================")
 }
 #endif
+
+#ifdef BUILD_TESTING
+#include <doctest/doctest.h>
+#else
+#define DOCTEST_CONFIG_DISABLE
+#include <doctest/doctest.h>
+#endif
+
+TEST_SUITE("Test MAC address validity")
+{
+    Network network;
+    Connection connection = Connection(&network);
+
+    TEST_CASE("Length Issues")
+    {
+        CHECK_THROWS(connection.setMAC("ab:cd:ef:01:23")); // Too short
+        CHECK_THROWS(connection.setMAC("ab:cd:ef:01:23:45:67")); // Too long
+    }
+
+    TEST_CASE("Invalid Separators")
+    {
+        CHECK_THROWS(connection.setMAC("ab-cd-ef-01-23-45")); // Wrong separator
+        CHECK_THROWS(
+            connection.setMAC("ab:cd.ef:01:23:45")); // Inconsistent separators
+    }
+
+    TEST_CASE("Incorrect Positioning of Separators")
+    {
+        CHECK_THROWS(
+            connection.setMAC(":ab:cd:ef:01:23:45")); // Leading separator
+        CHECK_THROWS(
+            connection.setMAC("ab:cd:ef:01:23:45:")); // Trailing separator
+        CHECK_THROWS(
+            connection.setMAC("ab:cd:ef:01:2:345")); // Misplaced separator
+    }
+
+    TEST_CASE("Invalid Characters")
+    {
+        CHECK_THROWS(connection.setMAC(
+            "ab:cd:ef:01:23:gh")); // Non-hexadecimal characters
+        CHECK_THROWS(
+            connection.setMAC("ab:cd:ef:01:23:45$")); // Special characters
+    }
+
+    TEST_CASE("Mixed Formats")
+    {
+        CHECK_THROWS(
+            connection.setMAC("abcd.ef:01:2345")); // Mixing different formats
+    }
+
+    TEST_CASE("Multicast Address")
+    {
+        CHECK_THROWS(connection.setMAC(
+            "01:00:5e:00:00:00")); // Multicast addresses are not typically used
+    }
+
+    TEST_CASE("Locally Administered Addresses")
+    {
+        CHECK_THROWS(connection.setMAC(
+            "02:00:5e:00:00:00")); // Locally administered address
+    }
+
+    TEST_CASE("Zeroed Address")
+    {
+        CHECK_THROWS(connection.setMAC(
+            "00:00:00:00:00:00")); // All zeros are not a valid hardware MAC
+                                   // address
+    }
+
+    TEST_CASE("Broadcast Address")
+    {
+        CHECK_THROWS(connection.setMAC(
+            "ff:ff:ff:ff:ff:ff")); // Reserved broadcast address
+    }
+}

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -114,16 +114,13 @@ address Network::fetchAddress(const std::string& interface)
     struct in_addr netmask { };
     struct in_addr network { };
 
-    // TODO: Fix exceptions
     if (inet_aton(
             Connection::fetchAddress(interface).to_string().c_str(), &addr)
         == 0)
-        return {};
-    // throw std::runtime_error("Invalid IP address");
+        throw std::runtime_error("Invalid IP address");
     if (inet_aton(fetchSubnetMask(interface).to_string().c_str(), &netmask)
         == 0)
-        return {};
-    // throw std::runtime_error("Invalid subnet mask address");
+        throw std::runtime_error("Invalid subnet mask address");
 
     network.s_addr = addr.s_addr & netmask.s_addr;
 
@@ -312,12 +309,13 @@ void Network::setDomainName(const std::string& domainName)
 
 std::string Network::fetchDomainName()
 {
-    if (res_init() == -1)
-        throw std::runtime_error("Failed to initialize domain name resolution");
+    char domainName[256]; // Adjust the buffer size as needed
+    if (getdomainname(domainName, sizeof(domainName)) == -1)
+        throw std::runtime_error("Failed to fetch domain name");
 
-    LOG_TRACE("Got domain name {}", _res.defdname);
+    LOG_TRACE("Got domain name {}", domainName);
 
-    return _res.defdname; // TODO: Seems to be a deprecated call
+    return std::string(domainName);
 }
 
 /* TODO: Check return type

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -63,6 +63,7 @@ void Server::setFQDN(const std::string& fqdn)
     if (fqdn.size() > 255)
         throw std::runtime_error("FQDN cannot be bigger than 255 characters");
 
+    // This pattern validates whether an FQDN is valid or not.
     const std::regex fqdnPattern(
         R"regex(^
     (                        # Start of FQDN

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -58,11 +58,30 @@ void Server::setHostname(std::string_view hostname)
 
 const std::string& Server::getFQDN() const noexcept { return m_fqdn; }
 
-/* TODO: Validate if FQDN is in right format */
 void Server::setFQDN(const std::string& fqdn)
 {
     if (fqdn.size() > 255)
         throw std::runtime_error("FQDN cannot be bigger than 255 characters");
+
+    const std::regex fqdnPattern(
+        R"regex(^
+    (                        # Start of FQDN
+        (                    # Start of label (subdomain)
+            [a-zA-Z0-9]       # First character of label
+            [a-zA-Z0-9\\-]*   # Zero or more valid characters in label
+            [a-zA-Z0-9]       # Last character of label
+        )                    # End of label
+        \.                   # Dot separator
+    )*                       # Zero or more labels
+    (                        # Start of last label (TLD)
+        [A-Za-z0-9]           # First character of label (TLD)
+        [A-Za-z0-9\\-]*       # Zero or more valid characters in label
+        [A-Za-z0-9]           # Last character of label (TLD)
+    )                        # End of last label (TLD)
+    $)regex");
+
+    if (!std::regex_match(fqdn, fqdnPattern))
+        throw std::runtime_error("Invalid FQDN format");
 
     m_fqdn = fqdn;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -129,7 +129,6 @@ const CPU& Server::getCPU() const noexcept { return m_cpu; }
 
 void Server::setCPU(const CPU& cpu) { m_cpu = cpu; }
 
-
 #ifdef BUILD_TESTING
 #include <doctest/doctest.h>
 #else
@@ -139,22 +138,26 @@ void Server::setCPU(const CPU& cpu) { m_cpu = cpu; }
 
 TEST_SUITE("Test FQDN")
 {
-    TEST_CASE("FQDN Validation with Server::setFQDN") {
+    TEST_CASE("FQDN Validation with Server::setFQDN")
+    {
         Server server;
 
-        SUBCASE("Valid FQDNs") {
+        SUBCASE("Valid FQDNs")
+        {
             CHECK_NOTHROW(server.setFQDN("example.com"));
             CHECK_NOTHROW(server.setFQDN("subdomain.example.com"));
             CHECK_NOTHROW(server.setFQDN("sub-domain.example.co.uk"));
         }
 
-        SUBCASE("Invalid FQDNs") {
+        SUBCASE("Invalid FQDNs")
+        {
             CHECK_THROWS(server.setFQDN("example")); // Missing TLD
             CHECK_THROWS(server.setFQDN(".example.com")); // Leading dot
             CHECK_THROWS(server.setFQDN("example.com.")); // Trailing dot
             CHECK_THROWS(server.setFQDN("example..com")); // Double dot
             CHECK_THROWS(server.setFQDN("example@com")); // Invalid character
-            CHECK_THROWS(server.setFQDN(std::string(256, 'a'))); // FQDN too long
+            CHECK_THROWS(
+                server.setFQDN(std::string(256, 'a'))); // FQDN too long
         }
     }
 }


### PR DESCRIPTION
Hey!

This PR is small and has few changes in different places. 
- Remove `connection` unused constructor
- Now `PresenterNetwork.h question` has more information about the network interface being dealt with
- Change the way `Connection::fetchInterfaces` deal with duplicates
- Improve readability on `Connection::setMAC` regex pattern and include Cisco MAC identifier
- Add specific Infiniband network MTU requirement in `Connection::setMTU` following [RFC4391](https://www.rfc-editor.org/rfc/rfc4391.html)
- Change `Network::fetchDomainName` to work with `getdomainname()` instead of `res_init`
- Add FQDN validation in `Server::setFQDN`