### PR TITLE
Remove network address question on TUI, calculate instead

### DIFF
--- a/include/cloysterhpc/presenter/PresenterNetwork.h
+++ b/include/cloysterhpc/presenter/PresenterNetwork.h
@@ -45,7 +45,6 @@ private:
         struct IP {
             static constexpr const char* address = "IP Address";
             static constexpr const char* subnetMask = "Subnet Mask";
-            static constexpr const char* network = "Network Address";
             static constexpr const char* gateway = "Gateway";
         };
 

--- a/src/presenter/PresenterNetwork.cpp
+++ b/src/presenter/PresenterNetwork.cpp
@@ -62,8 +62,6 @@ void PresenterNetwork::createNetwork()
               Connection::fetchAddress(interface).to_string() },
             { Messages::IP::subnetMask,
                 Network::fetchSubnetMask(interface).to_string() },
-            { Messages::IP::network,
-                Network::fetchAddress(interface).to_string() },
             { Messages::IP::gateway,
                 Network::fetchGateway(interface).to_string() },
             // Nameserver definitions
@@ -82,7 +80,8 @@ void PresenterNetwork::createNetwork()
     std::size_t i = 0;
     m_connection.setAddress(networkDetails[i++].second);
     m_network->setSubnetMask(networkDetails[i++].second);
-    m_network->setAddress(networkDetails[i++].second);
+    m_network->setAddress(
+        m_network->calculateAddress(m_connection.getAddress()));
     m_network->setGateway(networkDetails[i++].second);
 
     // Domain Data


### PR DESCRIPTION
Network address was required on TUI, now it is calculated.