### PR TITLE
[CLOYSTER-90] Integrate 'hwinfo' library

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -4,9 +4,6 @@
     <Objective-C>
       <option name="HEADER_GUARD_STYLE_PATTERN" value="${PROJECT_NAME}_${FILE_NAME}_${EXT}_" />
     </Objective-C>
-    <clangFormatSettings>
-      <option name="ENABLED" value="true" />
-    </clangFormatSettings>
     <codeStyleSettings language="Markdown">
       <option name="RIGHT_MARGIN" value="0" />
     </codeStyleSettings>

--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -84,6 +84,15 @@ function(cloysterhpc_setup_dependencies)
     endif()
   endif()
 
+  if(NOT TARGET hwinfo::HWinfo)
+    CPMAddPackage(
+            NAME hwinfo
+            GITHUB_REPOSITORY lfreist/hwinfo
+            GIT_TAG main
+            OPTIONS "NO_OCL ON"
+    )
+  endif()
+
   # Packages only available with CPM
   #if(NOT TARGET tools::tools)
   #  CPMAddPackage("gh:lefticus/tools#update_build_system")

--- a/cmake/CommonLibraries.cmake
+++ b/cmake/CommonLibraries.cmake
@@ -13,4 +13,5 @@ set(COMMON_LIBS
   SimpleIni::SimpleIni
   resolv
   ${STDC++FS}
-  doctest::doctest)
+  doctest::doctest
+  hwinfo::HWinfo)

--- a/include/cloysterhpc/hardware.h
+++ b/include/cloysterhpc/hardware.h
@@ -1,0 +1,48 @@
+/*
+ * Created by Lucas Gracioso <contact@lbgracioso.net>
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+#ifndef CLOYSTERHPC_HARDWARE_H_
+#define CLOYSTERHPC_HARDWARE_H_
+
+#include <hwinfo/hwinfo.h>
+
+class Hardware {
+private:
+    std::vector<hwinfo::CPU> m_cpu;
+    std::vector<hwinfo::Disk> m_disk;
+    std::vector<hwinfo::GPU> m_gpu;
+    hwinfo::MainBoard m_mobo;
+    hwinfo::Memory m_memory;
+    hwinfo::OS m_os;
+
+    static int64_t convertByteToGB(int64_t bytes);
+
+    void printHardwareInfo();
+
+    void printMotherboardInfo() const;
+
+    void printDiskInfo();
+
+    void printGPUInfo();
+
+public:
+    Hardware();
+
+    [[nodiscard]] std::vector<hwinfo::CPU> getCPU() const;
+
+    [[nodiscard]] std::vector<hwinfo::Disk> getDisk() const;
+
+    [[nodiscard]] std::vector<hwinfo::GPU> getGPU() const;
+
+    [[nodiscard]] hwinfo::MainBoard getMainBoard() const;
+
+    [[nodiscard]] hwinfo::Memory getMemory() const;
+
+    [[nodiscard]] hwinfo::OS getOS() const;
+
+    void printOverview();
+};
+
+#endif //CLOYSTERHPC_HARDWARE_H_

--- a/include/cloysterhpc/hardware.h
+++ b/include/cloysterhpc/hardware.h
@@ -1,7 +1,7 @@
 /*
  * Created by Lucas Gracioso <contact@lbgracioso.net>
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 
 #ifndef CLOYSTERHPC_HARDWARE_H_
 #define CLOYSTERHPC_HARDWARE_H_
@@ -45,4 +45,4 @@ public:
     void printOverview();
 };
 
-#endif //CLOYSTERHPC_HARDWARE_H_
+#endif // CLOYSTERHPC_HARDWARE_H_

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -1,42 +1,32 @@
 /*
  * Created by Lucas Gracioso <contact@lbgracioso.net>
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 
 #include "cloysterhpc/hardware.h"
 #include <fmt/format.h>
 
-std::vector<hwinfo::CPU> Hardware::getCPU() const {
-    return m_cpu;
-}
+std::vector<hwinfo::CPU> Hardware::getCPU() const { return m_cpu; }
 
-std::vector<hwinfo::Disk> Hardware::getDisk() const {
-    return m_disk;
-}
+std::vector<hwinfo::Disk> Hardware::getDisk() const { return m_disk; }
 
-std::vector<hwinfo::GPU> Hardware::getGPU() const {
-    return m_gpu;
-}
+std::vector<hwinfo::GPU> Hardware::getGPU() const { return m_gpu; }
 
-hwinfo::MainBoard Hardware::getMainBoard() const {
-    return m_mobo;
-}
+hwinfo::MainBoard Hardware::getMainBoard() const { return m_mobo; }
 
-hwinfo::Memory Hardware::getMemory() const {
-    return m_memory;
-}
+hwinfo::Memory Hardware::getMemory() const { return m_memory; }
 
-hwinfo::OS Hardware::getOS() const {
-    return m_os;
-}
+hwinfo::OS Hardware::getOS() const { return m_os; }
 
-Hardware::Hardware() {
+Hardware::Hardware()
+{
     m_cpu = hwinfo::getAllCPUs();
     m_disk = hwinfo::getAllDisks();
     m_gpu = hwinfo::getAllGPUs();
 }
 
-void Hardware::printOverview() {
+void Hardware::printOverview()
+{
     fmt::println("Operational System:\n");
     fmt::println("     Operational System Overview:\n");
     fmt::println("        System Version: {}", m_os.name());
@@ -49,7 +39,8 @@ void Hardware::printOverview() {
     printGPUInfo();
 }
 
-void Hardware::printHardwareInfo() {
+void Hardware::printHardwareInfo()
+{
     fmt::println("Hardware:\n");
     fmt::println("     Hardware Overview:\n");
     fmt::println("        Chip: {}", m_cpu[0].modelName());
@@ -57,34 +48,36 @@ void Hardware::printHardwareInfo() {
     fmt::println("        Logical Cores: {}", m_cpu[0].numLogicalCores());
     fmt::println("        Vendor: {}", m_cpu[0].vendor());
     fmt::println("        Memory: {} GB ({} bytes)",
-                 convertByteToGB(m_memory.total_Bytes()),
-                 m_memory.total_Bytes());
+        convertByteToGB(m_memory.total_Bytes()), m_memory.total_Bytes());
     fmt::println("");
 }
 
-void Hardware::printGPUInfo() {
+void Hardware::printGPUInfo()
+{
     fmt::println("     GPUs Overview:\n");
-    for (auto const& gpu: m_gpu) {
+    for (auto const& gpu : m_gpu) {
         fmt::println("        {}: ", gpu.name());
         fmt::println("           Total Memory: {} GB ({} bytes)",
-                     convertByteToGB(gpu.memory_Bytes()), gpu.memory_Bytes());
+            convertByteToGB(gpu.memory_Bytes()), gpu.memory_Bytes());
         fmt::println("           Total Number of Cores: {}", gpu.num_cores());
     }
     fmt::println("");
 }
 
-void Hardware::printDiskInfo() {
+void Hardware::printDiskInfo()
+{
     fmt::println("     Disks Overview:\n");
-    for (auto const &disk: m_disk) {
+    for (auto const& disk : m_disk) {
         fmt::println("        {}: ", disk.model());
         fmt::println("           Total Size: {} GB ({} bytes)",
-                     convertByteToGB(disk.size_Bytes()), disk.size_Bytes());
+            convertByteToGB(disk.size_Bytes()), disk.size_Bytes());
         fmt::println("           Serial Number: {}", disk.serialNumber());
     }
     fmt::println("");
 }
 
-void Hardware::printMotherboardInfo() const {
+void Hardware::printMotherboardInfo() const
+{
     fmt::println("     Motherboard Overview:\n");
     fmt::println("        Name: {}", m_mobo.name());
     fmt::println("        Version: {}", m_mobo.version());
@@ -93,7 +86,8 @@ void Hardware::printMotherboardInfo() const {
     fmt::println("");
 }
 
-int64_t Hardware::convertByteToGB(int64_t bytes) {
+int64_t Hardware::convertByteToGB(int64_t bytes)
+{
     return bytes / 1073741824;
     // 1073741824 is the same as static_cast<int64_t>(std::pow(1024,3))
 }

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -1,0 +1,99 @@
+/*
+ * Created by Lucas Gracioso <contact@lbgracioso.net>
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+#include "cloysterhpc/hardware.h"
+#include <fmt/format.h>
+
+std::vector<hwinfo::CPU> Hardware::getCPU() const {
+    return m_cpu;
+}
+
+std::vector<hwinfo::Disk> Hardware::getDisk() const {
+    return m_disk;
+}
+
+std::vector<hwinfo::GPU> Hardware::getGPU() const {
+    return m_gpu;
+}
+
+hwinfo::MainBoard Hardware::getMainBoard() const {
+    return m_mobo;
+}
+
+hwinfo::Memory Hardware::getMemory() const {
+    return m_memory;
+}
+
+hwinfo::OS Hardware::getOS() const {
+    return m_os;
+}
+
+Hardware::Hardware() {
+    m_cpu = hwinfo::getAllCPUs();
+    m_disk = hwinfo::getAllDisks();
+    m_gpu = hwinfo::getAllGPUs();
+}
+
+void Hardware::printOverview() {
+    fmt::println("Operational System:\n");
+    fmt::println("     Operational System Overview:\n");
+    fmt::println("        System Version: {}", m_os.name());
+    fmt::println("        Kernel Version: {}", m_os.kernel());
+    fmt::println("");
+
+    printHardwareInfo();
+    printMotherboardInfo();
+    printDiskInfo();
+    printGPUInfo();
+}
+
+void Hardware::printHardwareInfo() {
+    fmt::println("Hardware:\n");
+    fmt::println("     Hardware Overview:\n");
+    fmt::println("        Chip: {}", m_cpu[0].modelName());
+    fmt::println("        Physical Cores: {}", m_cpu[0].numPhysicalCores());
+    fmt::println("        Logical Cores: {}", m_cpu[0].numLogicalCores());
+    fmt::println("        Vendor: {}", m_cpu[0].vendor());
+    fmt::println("        Memory: {} GB ({} bytes)",
+                 convertByteToGB(m_memory.total_Bytes()),
+                 m_memory.total_Bytes());
+    fmt::println("");
+}
+
+void Hardware::printGPUInfo() {
+    fmt::println("     GPUs Overview:\n");
+    for (auto const &gpu: m_gpu) {
+        fmt::println("        {}: ", gpu.name());
+        fmt::println("           Total Memory: {} GB ({} bytes)",
+                     convertByteToGB(gpu.memory_Bytes()), gpu.memory_Bytes());
+        fmt::println("           Total Number of Cores: {}", gpu.num_cores());
+    }
+    fmt::println("");
+}
+
+void Hardware::printDiskInfo() {
+    fmt::println("     Disks Overview:\n");
+    for (auto const &disk: m_disk) {
+        fmt::println("        {}: ", disk.model());
+        fmt::println("           Total Size: {} GB ({} bytes)",
+                     convertByteToGB(disk.size_Bytes()), disk.size_Bytes());
+        fmt::println("           Serial Number: {}", disk.serialNumber());
+    }
+    fmt::println("");
+}
+
+void Hardware::printMotherboardInfo() const {
+    fmt::println("     Motherboard Overview:\n");
+    fmt::println("        Name: {}", m_mobo.name());
+    fmt::println("        Version: {}", m_mobo.version());
+    fmt::println("        Vendor: {}", m_mobo.vendor());
+    fmt::println("        Serial Number: {}", m_mobo.serialNumber());
+    fmt::println("");
+}
+
+int64_t Hardware::convertByteToGB(int64_t bytes) {
+    return bytes / 1073741824;
+    // 1073741824 is the same as static_cast<int64_t>(std::pow(1024,3))
+}

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -64,7 +64,7 @@ void Hardware::printHardwareInfo() {
 
 void Hardware::printGPUInfo() {
     fmt::println("     GPUs Overview:\n");
-    for (auto const &gpu: m_gpu) {
+    for (auto const& gpu: m_gpu) {
         fmt::println("        {}: ", gpu.name());
         fmt::println("           Total Memory: {} GB ({} bytes)",
                      convertByteToGB(gpu.memory_Bytes()), gpu.memory_Bytes());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdlib>
 
+#include "cloysterhpc/hardware.h"
 #include <CLI/CLI.hpp>
 #include <cloysterhpc/cloyster.h>
 #include <cloysterhpc/cluster.h>
@@ -15,7 +16,6 @@
 #include <cloysterhpc/verification.h>
 #include <cloysterhpc/view/newt.h>
 #include <internal_use_only/config.hpp>
-#include "cloysterhpc/hardware.h"
 
 #ifdef _CLOYSTER_I18N
 #include "include/i18n-cpp.hpp"
@@ -24,17 +24,18 @@
 /**
  * @brief The entrypoint.
  */
-int main(int argc, const char **argv) {
-    CLI::App app{productName};
+int main(int argc, const char** argv)
+{
+    CLI::App app { productName };
 
     app.add_flag(
-            "-v, --version", cloyster::showVersion, "Show version information");
+        "-v, --version", cloyster::showVersion, "Show version information");
 
     app.add_flag(
-            "-r, --root", cloyster::runAsRoot, "Run with root permissions");
+        "-r, --root", cloyster::runAsRoot, "Run with root permissions");
 
     app.add_flag(
-            "-d, --dry", cloyster::dryRun, "Perform a dry run installation");
+        "-d, --dry", cloyster::dryRun, "Perform a dry run installation");
 
     app.add_flag("-t, --tui", cloyster::enableTUI, "Enable TUI");
 
@@ -43,54 +44,53 @@ int main(int argc, const char **argv) {
     app.add_flag("-D, --daemon", cloyster::runAsDaemon, "Run as a daemon");
 
     cloyster::logLevelInput
-            = fmt::format("{}", magic_enum::enum_name(Log::Level::Info));
-    constexpr std::size_t logLevels{magic_enum::enum_count<Log::Level>()};
+        = fmt::format("{}", magic_enum::enum_name(Log::Level::Info));
+    constexpr std::size_t logLevels { magic_enum::enum_count<Log::Level>() };
 
     const std::vector<std::string> logLevelVector = []() {
-        constexpr const auto &logLevelNames{
-                magic_enum::enum_names<Log::Level>()
+        constexpr const auto& logLevelNames {
+            magic_enum::enum_names<Log::Level>()
         };
-        return std::vector<std::string>{logLevelNames.begin(),
-                                        logLevelNames.end()};
+        return std::vector<std::string> { logLevelNames.begin(),
+            logLevelNames.end() };
     }();
 
     app.add_option("-l, --log-level", cloyster::logLevelInput,
-                   [&logLevelVector]() {
-                       std::string result{"Available log levels:"};
+           [&logLevelVector]() {
+               std::string result { "Available log levels:" };
 
-                       for (std::size_t i = 0; const auto &logLevel: logLevelVector) {
-                           result += fmt::format(" {} ({}),", logLevel, i++);
-                       }
+               for (std::size_t i = 0; const auto& logLevel : logLevelVector) {
+                   result += fmt::format(" {} ({}),", logLevel, i++);
+               }
 
-                       result.pop_back();
-                       return result;
-                   }())
-            ->check(CLI::IsMember(logLevelVector, CLI::ignore_case)
-                    | CLI::Range(logLevels - 1))
-                    // This is a hack to solve the autogen string:
-                    // -l,--log-level TEXT:({Trace,Debug,Info,Warn,Error,Critical,Off})
-                    // OR (INT in [0 - 6])
-            ->option_text(" ");
+               result.pop_back();
+               return result;
+           }())
+        ->check(CLI::IsMember(logLevelVector, CLI::ignore_case)
+            | CLI::Range(logLevels - 1))
+        // This is a hack to solve the autogen string:
+        // -l,--log-level TEXT:({Trace,Debug,Info,Warn,Error,Critical,Off})
+        // OR (INT in [0 - 6])
+        ->option_text(" ");
 
     app.add_option(
-            "-a, --answerfile", cloyster::answerfile,
-            "Full path to a answerfile");
+        "-a, --answerfile", cloyster::answerfile, "Full path to a answerfile");
 
     bool showHardwareInfo = false;
     app.add_flag("-i, --hardwareinfo", showHardwareInfo,
-                 "Show a detailed hardware and system overview");
+        "Show a detailed hardware and system overview");
 
     CLI11_PARSE(app, argc, argv)
 
     Log::init([]() {
         if (std::regex_match(cloyster::logLevelInput, std::regex("^[0-9]+$"))) {
             return magic_enum::enum_cast<Log::Level>(
-                    stoi(cloyster::logLevelInput))
-                    .value();
+                stoi(cloyster::logLevelInput))
+                .value();
         } else {
             return magic_enum::enum_cast<Log::Level>(
-                    cloyster::logLevelInput, magic_enum::case_insensitive)
-                    .value();
+                cloyster::logLevelInput, magic_enum::case_insensitive)
+                .value();
         }
     }());
 
@@ -152,10 +152,10 @@ int main(int argc, const char **argv) {
 
         LOG_TRACE("Starting execution engine");
         std::unique_ptr<Execution> executionEngine
-                = std::make_unique<Shell>(model);
+            = std::make_unique<Shell>(model);
         executionEngine->install();
 
-    } catch (const std::exception &e) {
+    } catch (const std::exception& e) {
         LOG_ERROR("ERROR: {}", e.what());
         return EXIT_FAILURE;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include <cloysterhpc/verification.h>
 #include <cloysterhpc/view/newt.h>
 #include <internal_use_only/config.hpp>
+#include "cloysterhpc/hardware.h"
 
 #ifdef _CLOYSTER_I18N
 #include "include/i18n-cpp.hpp"
@@ -23,18 +24,17 @@
 /**
  * @brief The entrypoint.
  */
-int main(int argc, const char** argv)
-{
-    CLI::App app { productName };
+int main(int argc, const char **argv) {
+    CLI::App app{productName};
 
     app.add_flag(
-        "-v, --version", cloyster::showVersion, "Show version information");
+            "-v, --version", cloyster::showVersion, "Show version information");
 
     app.add_flag(
-        "-r, --root", cloyster::runAsRoot, "Run with root permissions");
+            "-r, --root", cloyster::runAsRoot, "Run with root permissions");
 
     app.add_flag(
-        "-d, --dry", cloyster::dryRun, "Perform a dry run installation");
+            "-d, --dry", cloyster::dryRun, "Perform a dry run installation");
 
     app.add_flag("-t, --tui", cloyster::enableTUI, "Enable TUI");
 
@@ -43,49 +43,54 @@ int main(int argc, const char** argv)
     app.add_flag("-D, --daemon", cloyster::runAsDaemon, "Run as a daemon");
 
     cloyster::logLevelInput
-        = fmt::format("{}", magic_enum::enum_name(Log::Level::Info));
-    constexpr std::size_t logLevels { magic_enum::enum_count<Log::Level>() };
+            = fmt::format("{}", magic_enum::enum_name(Log::Level::Info));
+    constexpr std::size_t logLevels{magic_enum::enum_count<Log::Level>()};
 
     const std::vector<std::string> logLevelVector = []() {
-        constexpr const auto& logLevelNames {
-            magic_enum::enum_names<Log::Level>()
+        constexpr const auto &logLevelNames{
+                magic_enum::enum_names<Log::Level>()
         };
-        return std::vector<std::string> { logLevelNames.begin(),
-            logLevelNames.end() };
+        return std::vector<std::string>{logLevelNames.begin(),
+                                        logLevelNames.end()};
     }();
 
     app.add_option("-l, --log-level", cloyster::logLevelInput,
-           [&logLevelVector]() {
-               std::string result { "Available log levels:" };
+                   [&logLevelVector]() {
+                       std::string result{"Available log levels:"};
 
-               for (std::size_t i = 0; const auto& logLevel : logLevelVector) {
-                   result += fmt::format(" {} ({}),", logLevel, i++);
-               }
+                       for (std::size_t i = 0; const auto &logLevel: logLevelVector) {
+                           result += fmt::format(" {} ({}),", logLevel, i++);
+                       }
 
-               result.pop_back();
-               return result;
-           }())
-        ->check(CLI::IsMember(logLevelVector, CLI::ignore_case)
-            | CLI::Range(logLevels - 1))
-        // This is a hack to solve the autogen string:
-        // -l,--log-level TEXT:({Trace,Debug,Info,Warn,Error,Critical,Off})
-        // OR (INT in [0 - 6])
-        ->option_text(" ");
+                       result.pop_back();
+                       return result;
+                   }())
+            ->check(CLI::IsMember(logLevelVector, CLI::ignore_case)
+                    | CLI::Range(logLevels - 1))
+                    // This is a hack to solve the autogen string:
+                    // -l,--log-level TEXT:({Trace,Debug,Info,Warn,Error,Critical,Off})
+                    // OR (INT in [0 - 6])
+            ->option_text(" ");
 
     app.add_option(
-        "-a, --answerfile", cloyster::answerfile, "Full path to a answerfile");
+            "-a, --answerfile", cloyster::answerfile,
+            "Full path to a answerfile");
+
+    bool showHardwareInfo = false;
+    app.add_flag("-i, --hardwareinfo", showHardwareInfo,
+                 "Show a detailed hardware and system overview");
 
     CLI11_PARSE(app, argc, argv)
 
     Log::init([]() {
         if (std::regex_match(cloyster::logLevelInput, std::regex("^[0-9]+$"))) {
             return magic_enum::enum_cast<Log::Level>(
-                stoi(cloyster::logLevelInput))
-                .value();
+                    stoi(cloyster::logLevelInput))
+                    .value();
         } else {
             return magic_enum::enum_cast<Log::Level>(
-                cloyster::logLevelInput, magic_enum::case_insensitive)
-                .value();
+                    cloyster::logLevelInput, magic_enum::case_insensitive)
+                    .value();
         }
     }());
 
@@ -96,6 +101,12 @@ int main(int argc, const char** argv)
     LOG_INFO("{} Started", productName);
 
     try {
+        if (showHardwareInfo) {
+            Hardware hardware;
+            hardware.printOverview();
+            return EXIT_SUCCESS;
+        }
+
         if (cloyster::showVersion) {
             fmt::print("{}: Version {}\n", productName, productVersion);
             return EXIT_SUCCESS;
@@ -141,10 +152,10 @@ int main(int argc, const char** argv)
 
         LOG_TRACE("Starting execution engine");
         std::unique_ptr<Execution> executionEngine
-            = std::make_unique<Shell>(model);
+                = std::make_unique<Shell>(model);
         executionEngine->install();
 
-    } catch (const std::exception& e) {
+    } catch (const std::exception &e) {
         LOG_ERROR("ERROR: {}", e.what());
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
Hey, this PR integrates 'hwinfo' library.

Basically there are two new things:
1. `hwinfo` library
2. `-i, --hardwareinfo` option to CLI
3. `Hardware` class 

Just to explain the functionality of `Hardware` class. For now, it works like "`Answerfile`" class. Later we can use this library and this class to gather data and assemble other ones (as example, `CPU` class). 

My  idea is that we can contribute to the `hwinfo` open-source project, as it will help us a lot with the hardware "issue" in Cloyster.