### PR TITLE
Get locales from the system

### DIFF
--- a/include/cloysterhpc/cluster.h
+++ b/include/cloysterhpc/cluster.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <string>
 
+#include "cloysterhpc/services/locale.h"
 #include <cloysterhpc/diskImage.h>
 #include <cloysterhpc/headnode.h>
 #include <cloysterhpc/mailsystem/postfix.h>
@@ -19,6 +20,7 @@
 #include <cloysterhpc/ofed.h>
 #include <cloysterhpc/queuesystem/pbs.h>
 #include <cloysterhpc/queuesystem/slurm.h>
+#include <cloysterhpc/services/locale.h>
 #include <cloysterhpc/services/timezone.h>
 
 class Cluster {
@@ -40,7 +42,7 @@ private:
     bool m_firewall { false };
     SELinuxMode m_selinux { SELinuxMode::Disabled };
     Timezone m_timezone;
-    std::string m_locale; /* Default locale cluster wide */
+    Locale m_locale; /* Default locale cluster wide */
     std::string m_domainName;
 
     std::list<std::unique_ptr<Network>> m_network;
@@ -64,7 +66,8 @@ public:
     void setSELinux(SELinuxMode);
     [[nodiscard]] Timezone& getTimezone();
     void setTimezone(const std::string& tz);
-    [[nodiscard]] const std::string& getLocale() const;
+    [[nodiscard]] const Locale& getLocale() const;
+    void setLocale(const Locale& locale);
     void setLocale(const std::string& locale);
     [[nodiscard]] const std::string& getDomainName() const;
     void setDomainName(const std::string& domainName);

--- a/include/cloysterhpc/services/locale.h
+++ b/include/cloysterhpc/services/locale.h
@@ -1,0 +1,28 @@
+/*
+ * Created by Lucas Gracioso <contact@lbgracioso.net>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CLOYSTERHPC_LOCALE_H_
+#define CLOYSTERHPC_LOCALE_H_
+
+#include <list>
+#include <string>
+
+class Locale {
+private:
+    std::string m_locale;
+    std::list<std::string> m_availableLocales;
+
+public:
+    Locale();
+    ~Locale() = default;
+
+    void setLocale(std::string_view locale);
+    std::string_view getLocale() const;
+
+    std::list<std::string> getAvailableLocales() const;
+    std::list<std::string> fetchAvailableLocales() const;
+};
+
+#endif // CLOYSTERHPC_LOCALE_H_

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -65,9 +65,14 @@ Timezone& Cluster::getTimezone() { return m_timezone; }
 
 void Cluster::setTimezone(const std::string& tz) { m_timezone.setTimezone(tz); }
 
-const std::string& Cluster::getLocale() const { return m_locale; }
+const Locale& Cluster::getLocale() const { return m_locale; }
 
-void Cluster::setLocale(const std::string& locale) { m_locale = locale; }
+void Cluster::setLocale(const Locale& locale) { m_locale = locale; }
+
+void Cluster::setLocale(const std::string& locale)
+{
+    m_locale.setLocale(locale);
+}
 
 const std::string& Cluster::getDomainName() const { return m_domainName; }
 
@@ -308,7 +313,7 @@ void Cluster::printData()
     LOG_DEBUG("OS Data:")
     m_headnode.getOS().printData();
     LOG_DEBUG("Timezone: {}", getTimezone().getTimezone());
-    LOG_DEBUG("Locale: {}", getLocale());
+    LOG_DEBUG("Locale: {}", getLocale().getLocale());
     LOG_DEBUG("Hostname: {}", this->m_headnode.getHostname());
     LOG_DEBUG("DomainName: {}", getDomainName());
     LOG_DEBUG("FQDN: {}", this->m_headnode.getFQDN());

--- a/src/presenter/PresenterLocale.cpp
+++ b/src/presenter/PresenterLocale.cpp
@@ -9,18 +9,11 @@ PresenterLocale::PresenterLocale(
     std::unique_ptr<Cluster>& model, std::unique_ptr<Newt>& view)
     : Presenter(model, view)
 {
-
-    // TODO: Get locales from the system
-    //    auto availableLocales = m_model->getLocale()
-    //                                    .getAvailableLocales();
-
-    // FIXME: For now we will only support those two locales
-    const auto& locales
-        = std::to_array<std::string_view>({ "en_US.UTF-8", "pt_BR.UTF-8" });
+    auto availableLocales = m_model->getLocale().getAvailableLocales();
 
     const auto& selectedLocale = m_view->listMenu(
-        Messages::title, Messages::question, locales, Messages::help);
+        Messages::title, Messages::question, availableLocales, Messages::help);
 
     m_model->setLocale(selectedLocale);
-    LOG_DEBUG("Locale set to: {}", m_model->getLocale());
+    LOG_DEBUG("Locale set to: {}", m_model->getLocale().getLocale())
 }

--- a/src/services/locale.cpp
+++ b/src/services/locale.cpp
@@ -1,0 +1,39 @@
+/*
+ * Created by Lucas Gracioso <contact@lbgracioso.net>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cloysterhpc/services/locale.h"
+#include "cloysterhpc/functions.h"
+#include <cloysterhpc/services/log.h>
+
+Locale::Locale()
+    : m_availableLocales { fetchAvailableLocales() }
+{
+}
+
+void Locale::setLocale(std::string_view locale)
+{
+    if (std::find(m_availableLocales.begin(), m_availableLocales.end(), locale)
+        != m_availableLocales.end())
+        m_locale = locale;
+    else
+        throw std::runtime_error("Unsupported locale");
+}
+
+std::string_view Locale::getLocale() const { return m_locale; }
+
+std::list<std::string> Locale::getAvailableLocales() const
+{
+    return m_availableLocales;
+}
+
+std::list<std::string> Locale::fetchAvailableLocales() const
+{
+    LOG_DEBUG("Fetching available system locales")
+    std::list<std::string> output;
+
+    cloyster::runCommand(fmt::format("locale -a"), output, true);
+
+    return output;
+}

--- a/src/services/shell.cpp
+++ b/src/services/shell.cpp
@@ -139,7 +139,8 @@ void Shell::configureLocale()
 {
     LOG_INFO("Setting up locale");
 
-    runCommand(fmt::format("localectl set-locale {}", m_cluster->getLocale()));
+    runCommand(fmt::format(
+        "localectl set-locale {}", m_cluster->getLocale().getLocale()));
 }
 
 void Shell::disableNetworkManagerDNSOverride()


### PR DESCRIPTION
Hey! Fast one.

This PR solves the "Get locales from the system" to-do.

A example of `PresenterLocale` after the changes.
![Example](https://github.com/viniciusferrao/cloysterhpc/assets/34951068/25b1fc35-4c23-478b-ac52-45f50f88d332)


