### PR TITLE
Remove EPEL 'Modular' for EL9 from getXCATOSImageRepos in repos.cpp

### DIFF
--- a/src/repos.cpp
+++ b/src/repos.cpp
@@ -215,6 +215,12 @@ std::vector<std::string> Repos::getxCATOSImageRepos() const
         fmt::format("https://mirror.versatushpc.com.br/epel/{}/Everything/{}",
             osMajorVersion, osArch));
 
+    if (osMajorVersion < 9) {
+        repos.emplace_back(
+            fmt::format("https://mirror.versatushpc.com.br/epel/{}/Modular/{}",
+                osMajorVersion, osArch));
+    }
+
     /* TODO: if OpenHPC statement */
     repos.emplace_back(
         fmt::format("https://mirror.versatushpc.com.br/openhpc/{}/EL_{}",

--- a/src/repos.cpp
+++ b/src/repos.cpp
@@ -214,8 +214,9 @@ std::vector<std::string> Repos::getxCATOSImageRepos() const
     repos.emplace_back(
         fmt::format("https://mirror.versatushpc.com.br/epel/{}/Everything/{}",
             osMajorVersion, osArch));
-
-    if (osMajorVersion < 9) {
+    
+    // Modular repositories are only available on EL8
+    if (osMajorVersion == 8) {
         repos.emplace_back(
             fmt::format("https://mirror.versatushpc.com.br/epel/{}/Modular/{}",
                 osMajorVersion, osArch));

--- a/src/repos.cpp
+++ b/src/repos.cpp
@@ -214,9 +214,6 @@ std::vector<std::string> Repos::getxCATOSImageRepos() const
     repos.emplace_back(
         fmt::format("https://mirror.versatushpc.com.br/epel/{}/Everything/{}",
             osMajorVersion, osArch));
-    repos.emplace_back(
-        fmt::format("https://mirror.versatushpc.com.br/epel/{}/Modular/{}",
-            osMajorVersion, osArch));
 
     /* TODO: if OpenHPC statement */
     repos.emplace_back(


### PR DESCRIPTION
**EPEL 9** removed 'Modular' but kept 'Everything'. 

The previous ones also have 'Everything', so we can use it by default.