### PR TITLE
Add postscript for InfiniBand

### DIFF
--- a/src/services/xcat.cpp
+++ b/src/services/xcat.cpp
@@ -118,8 +118,6 @@ void XCAT::configureInfiniband()
         switch (ofed->getKind()) {
             case OFED::Kind::Inbox:
                 m_stateless.otherpkgs.emplace_back("@infiniband");
-                cloyster::runCommand(
-                    "chdef compute -p postscripts=confignetwork");
                 break;
 
             case OFED::Kind::Mellanox:
@@ -131,6 +129,8 @@ void XCAT::configureInfiniband()
                     "Oracle RDMA release is not yet supported");
                 break;
         }
+
+    cloyster::runCommand("chdef compute -p postscripts=confignetwork");
 }
 
 void XCAT::configureSLURM()

--- a/src/services/xcat.cpp
+++ b/src/services/xcat.cpp
@@ -118,18 +118,17 @@ void XCAT::configureInfiniband()
         switch (ofed->getKind()) {
             case OFED::Kind::Inbox:
                 m_stateless.otherpkgs.emplace_back("@infiniband");
-
+                cloyster::runCommand(
+                    "chdef compute -p postscripts=confignetwork");
                 break;
 
             case OFED::Kind::Mellanox:
                 throw std::logic_error("MLNX OFED is not yet supported");
-
                 break;
 
             case OFED::Kind::Oracle:
                 throw std::logic_error(
                     "Oracle RDMA release is not yet supported");
-
                 break;
         }
 }


### PR DESCRIPTION
This PR is to fix issue #38 

Run `chdef compute -p postscripts=confignetwork` to configure InfiniBand (if using it).