### PR TITLE
Fix 'throw' messages throughout the code

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -82,7 +82,8 @@ const std::string& Cluster::getDomainName() const { return m_domainName; }
 void Cluster::setDomainName(const std::string& domainName)
 {
     if (domainName.size() > 255)
-        throw;
+        throw std::length_error("Domain name exceeds the maximum allowed "
+                                "length of 255 characters.");
 
 #if __cpp_lib_starts_ends_with >= 201711L
     if (domainName.starts_with('-') or domainName.ends_with('-'))
@@ -94,11 +95,14 @@ void Cluster::setDomainName(const std::string& domainName)
 
     /* Check if string has only digits */
     if (std::regex_match(domainName, std::regex("^[0-9]+$")))
-        throw;
+        throw std::invalid_argument(
+            "Domain name should not consist solely of numeric digits.");
 
     /* Check if it's not only alphanumerics and - */
     if (!(std::regex_match(domainName, std::regex("^[A-Za-z0-9-.]+$"))))
-        throw;
+        throw std::invalid_argument(
+            "Domain name contains invalid characters. Only alphanumeric "
+            "characters and hyphens are allowed.");
 
     m_domainName = domainName;
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -277,7 +277,7 @@ uint16_t Network::getVLAN() const { return m_vlan; }
 void Network::setVLAN(uint16_t vlan)
 {
     if (vlan >= 4096)
-        throw;
+        throw std::out_of_range("VLAN value must be less than 4096.");
     m_vlan = vlan;
 }
 
@@ -286,7 +286,8 @@ const std::string& Network::getDomainName() const { return m_domainName; }
 void Network::setDomainName(const std::string& domainName)
 {
     if (domainName.size() > 255)
-        throw;
+        throw std::length_error("Domain name exceeds the maximum allowed "
+                                "length of 255 characters.");
 
 #if __cpp_lib_starts_ends_with >= 201711L
     if (domainName.starts_with('-') or domainName.ends_with('-'))
@@ -298,11 +299,14 @@ void Network::setDomainName(const std::string& domainName)
 
     /* Check if string has only digits */
     if (std::regex_match(domainName, std::regex("^[0-9]+$")))
-        throw;
+        throw std::invalid_argument(
+            "Domain name should not consist solely of numeric digits.");
 
     /* Check if it's not only alphanumerics and - */
     if (!(std::regex_match(domainName, std::regex("^[A-Za-z0-9-.]+$"))))
-        throw;
+        throw std::invalid_argument(
+            "Domain name contains invalid characters. Only alphanumeric "
+            "characters and hyphens are allowed.");
 
     m_domainName = domainName;
 }

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -160,7 +160,7 @@ void OS::setDistro(std::string_view distro)
 #if 0
     if (const auto& rv = magic_enum::enum_cast<Distro>(distro, magic_enum::case_insensitive))
 #endif
-    if (const auto &rv
+    if (const auto& rv
         = magic_enum::enum_cast<Distro>(distro, [](char lhs, char rhs) {
               return std::tolower(lhs) == std::tolower(rhs);
           }))

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -41,7 +41,8 @@ OS::OS()
 
         if (!file.is_open()) {
             perror(("Error while opening file " + filename).c_str());
-            throw; /* Error opening file */
+            throw std::runtime_error(
+                fmt::format("Error while opening file: {}", filename));
         }
 
         /* Fetches OS information from /etc/os-release. The file is writen in a
@@ -83,7 +84,8 @@ OS::OS()
 
         if (file.bad()) {
             perror(("Error while reading file " + filename).c_str());
-            throw; /* Error while reading file */
+            throw std::runtime_error(
+                fmt::format("Error while reading file: {}", filename));
         }
     }
 }
@@ -158,7 +160,7 @@ void OS::setDistro(std::string_view distro)
 #if 0
     if (const auto& rv = magic_enum::enum_cast<Distro>(distro, magic_enum::case_insensitive))
 #endif
-    if (const auto& rv
+    if (const auto &rv
         = magic_enum::enum_cast<Distro>(distro, [](char lhs, char rhs) {
               return std::tolower(lhs) == std::tolower(rhs);
           }))
@@ -177,7 +179,8 @@ unsigned int OS::getMajorVersion() const { return m_majorVersion; }
 void OS::setMajorVersion(unsigned int majorVersion)
 {
     if (majorVersion < 8)
-        throw; /* Unsupported release */
+        throw std::runtime_error(
+            "Unsupported release: Major version must be 8 or greater.");
 
     m_majorVersion = majorVersion;
 }
@@ -187,7 +190,8 @@ unsigned int OS::getMinorVersion() const { return m_minorVersion; }
 void OS::setMinorVersion(unsigned int minorVersion)
 {
     if (minorVersion < 1)
-        throw; /* Unsupported minor release */
+        throw std::runtime_error(
+            "Unsupported release: Minor version must be 1 or greater.");
 
     m_minorVersion = minorVersion;
 }

--- a/src/view/newtOkCancelMessage.cpp
+++ b/src/view/newtOkCancelMessage.cpp
@@ -29,7 +29,8 @@ void Newt::okCancelMessage(const char* title, const char* message)
             abort();
             break;
         default:
-            throw;
+            throw std::runtime_error(
+                "Something happened. Please run the software again");
     }
 }
 


### PR DESCRIPTION
Many errors were set to throw just as `throw;` instead of giving a message together. Now it's fixed.