### PR TITLE
Fix repos.cpp Rocky 'vault' branch check

### DIFF
--- a/src/repos.cpp
+++ b/src/repos.cpp
@@ -158,7 +158,7 @@ std::vector<std::string> Repos::getxCATOSImageRepos() const
     }
 
     if (std::find(latestEL.begin(), latestEL.end(), osVersion)
-        != latestEL.end()) {
+        == latestEL.end()) {
         rockyBranch = "vault";
     }
 

--- a/src/repos.cpp
+++ b/src/repos.cpp
@@ -143,7 +143,7 @@ std::vector<std::string> Repos::getxCATOSImageRepos() const
 
     std::vector<std::string> repos;
 
-    std::string latestEL = "9.3";
+    std::vector<std::string> latestEL = { "8,9", "9.3" };
 
     std::string crb = "CRB";
     std::string rockyBranch
@@ -157,7 +157,8 @@ std::vector<std::string> Repos::getxCATOSImageRepos() const
         OpenHPCVersion = "2";
     }
 
-    if (osVersion != latestEL) {
+    if (std::find(latestEL.begin(), latestEL.end(), osVersion)
+        != latestEL.end()) {
         rockyBranch = "vault";
     }
 

--- a/src/repos.cpp
+++ b/src/repos.cpp
@@ -143,7 +143,7 @@ std::vector<std::string> Repos::getxCATOSImageRepos() const
 
     std::vector<std::string> repos;
 
-    std::vector<std::string> latestEL = { "8,9", "9.3" };
+    std::vector<std::string> latestEL = { "8.9", "9.3" };
 
     std::string crb = "CRB";
     std::string rockyBranch


### PR DESCRIPTION
This fixes Rocky 8.9 repos (because 8.9 is out of 'vault' branch).