### PR TITLE
Patch Mellanox OFED with mlnxofed-patch

### DIFF
--- a/include/cloysterhpc/ofed.h
+++ b/include/cloysterhpc/ofed.h
@@ -14,6 +14,7 @@ public:
 
 private:
     Kind m_kind { Kind::Inbox };
+    void patchMellanox() const;
 
 public:
     OFED() = default;

--- a/src/ofed.cpp
+++ b/src/ofed.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "cloysterhpc/services/log.h"
 #include <cloysterhpc/ofed.h>
 
 using cloyster::runCommand;
@@ -26,7 +27,7 @@ void OFED::install() const
 
         case OFED::Kind::Mellanox:
             throw std::logic_error("MLNX OFED is not yet supported");
-
+            patchMellanox();
             break;
 
         case OFED::Kind::Oracle:
@@ -34,4 +35,13 @@ void OFED::install() const
 
             break;
     }
+}
+
+void OFED::patchMellanox() const
+{
+    LOG_TRACE("Patching Mellanox OFED")
+
+    runCommand("wget -O - "
+               "https://raw.githubusercontent.com/viniciusferrao/"
+               "mlnxofed-patch/master/patch-mlnxofed.sh | bash");
 }


### PR DESCRIPTION
This PR adds [mlnxofed-patch](https://github.com/viniciusferrao/mlnxofed-patch) to patch it.

> [!NOTE]  
> MLNX is not yet supported, but the patch is already available so we won't forget about it in the future.