### PR TITLE
[CLOYSTER-104] Preliminary support to dbus, plus a daemon management class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -315,3 +315,5 @@ tags
 
 # Vagrant auto-generated folder
 .vagrant
+
+.cache/

--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -94,6 +94,20 @@ function(cloysterhpc_setup_dependencies)
     endif()
   endif()
 
+  if(NOT TARGET SDBusCpp::sdbus-c++)
+    if (cloysterhpc_ENABLE_CONAN)
+      CPMFindPackage(NAME sdbus-c++)
+    else()
+      CPMAddPackage(
+        NAME
+        sdbus-c++
+        VERSION
+        2.0.0
+        GITHUB_REPOSITORY
+        "Kistler-Groups/sdbus-cpp")
+    endif()
+  endif()
+
   # Packages only available with CPM
   #if(NOT TARGET tools::tools)
   #  CPMAddPackage("gh:lefticus/tools#update_build_system")

--- a/cmake/CommonLibraries.cmake
+++ b/cmake/CommonLibraries.cmake
@@ -14,4 +14,5 @@ set(COMMON_LIBS
   resolv
   ${STDC++FS}
   doctest::doctest
-  cryptopp::cryptopp)
+  cryptopp::cryptopp
+  SDBusCpp::sdbus-c++)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -8,6 +8,7 @@ magic_enum/0.9.2
 gsl-lite/0.40.0
 doctest/2.4.11
 cryptopp/8.7.0
+sdbus-cpp/2.0.0
 
 [layout]
 cmake_layout

--- a/include/cloysterhpc/daemon_handler.h
+++ b/include/cloysterhpc/daemon_handler.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <cloysterhpc/messagebus.h>
+
+class DaemonHandler {
+private:
+    std::shared_ptr<MessageBus> m_bus;
+    const std::string m_name;
+
+    template <typename... Ts>
+    sdbus::ObjectPath callObjectFunction(
+        const std::string function, Ts... params)
+    {
+        MessageReply reply
+            = m_bus->method("org.freedesktop.systemd1.Manager", function)
+                  ->call(m_name, params...);
+        return reply.get<sdbus::ObjectPath>();
+    }
+
+    static std::string fixServiceName(std::string name);
+
+public:
+    DaemonHandler(std::shared_ptr<MessageBus> bus, const std::string name)
+        : m_bus(bus)
+        , m_name(DaemonHandler::fixServiceName(name))
+    {
+    }
+
+    static void daemonReload(MessageBus& bus);
+
+    bool exists();
+
+    void load();
+    void start();
+    void stop();
+    void restart();
+    void enable();
+    void disable();
+};

--- a/include/cloysterhpc/messagebus.h
+++ b/include/cloysterhpc/messagebus.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <any>
+#include <memory>
+#include <sdbus-c++/sdbus-c++.h>
+#include <string>
+#include <type_traits>
+#include <variant>
+
+/**
+ * Not much to be done here... just our simple needs for an answer type
+ *
+ * We also require compatibility with sdbus, but sdbus errors are enough to
+ * tell this to the user
+ */
+template <typename T>
+concept MessageReturnable = std::is_nothrow_default_constructible<T>::value;
+
+/**
+ * A more or less "generic"-ish way to refer to a message reply
+ * Encapsulates the sdbus answer so we can mock answers for testing
+ *
+ * Unfortunately, to increase testability (and mockability), we need to
+ * make this class aware of the real answer type and the mock answer type
+ *
+ * This will be worth when we start mocking services, I promise...
+ */
+class MessageReply {
+private:
+    std::variant<sdbus::MethodReply, std::any> m_base_reply;
+
+public:
+    MessageReply(sdbus::MethodReply&& reply)
+        : m_base_reply(reply)
+    {
+    }
+
+    MessageReply(std::any&& reply)
+        : m_base_reply(reply)
+    {
+    }
+
+    template <class... Ts> struct overloaded : Ts... {
+        using Ts::operator()...;
+    };
+
+    template <MessageReturnable T> T get()
+    {
+        return std::visit(
+            overloaded {
+                [](sdbus::MethodReply arg) {
+                    T result {};
+                    arg >> result;
+                    return result;
+                },
+                [](std::any arg) { return std::any_cast<T>(arg); },
+            },
+            m_base_reply);
+    }
+};
+
+/**
+ * All possible parameter types for dbus (to be filled)
+ *
+ * For more complex types (rarely from what I saw) please add them
+ * here or use sdbus-cpp directly... it is not hard, but you will
+ * lose mockability.
+ */
+using MethodParamVariant
+    = std::variant<unsigned char, short, int, long int, bool, std::string,
+        const char*, sdbus::ObjectPath, std::vector<unsigned char>,
+        std::vector<std::string>, std::vector<sdbus::ObjectPath>>;
+
+class MessageBusMethod {
+protected:
+    virtual void pushSingleParam(MethodParamVariant param) = 0;
+    virtual MessageReply callMethod() = 0;
+    bool finished = false;
+
+public:
+    void addParams() { }
+
+    template <typename T, typename... Ts> void addParams(T param, Ts... params)
+    {
+        this->pushSingleParam(param);
+        this->addParams(params...);
+    }
+
+    template <typename... Ts> MessageReply call(Ts... params)
+    {
+        if (finished) {
+            throw std::runtime_error {
+                "Only one ->call() is permitted per method()"
+            };
+        }
+
+        this->addParams(params...);
+
+        finished = true;
+        return this->callMethod();
+    }
+
+    virtual ~MessageBusMethod() { }
+};
+
+/**
+ * A class for communicating with a message bus (usually dbus, but this can be
+ * changed with some effort.
+ *
+ * You need to instantiate some specific bus (like DBusClient or the
+ * TestBusClient) and call a function there
+ *
+ * The syntax is like this:
+ * ```cpp
+ *
+ * std::unique_ptr<MessageBus> client = make_a_bus_in_some_way();
+ * auto replyObject = client->method("org.mybus.MyInterface",
+ * "MyMethod")->call(param1, param2); auto reply =
+ * replyObject.get<MyMethodReturnType>();
+ * ```
+ *
+ * Check sdbus guide for the method return types, we will copy theirs because it
+ * is not worth to encapsulate (too hard with no gain)
+ */
+class MessageBus {
+public:
+    [[nodiscard]] virtual std::unique_ptr<MessageBusMethod> method(
+        std::string interface, std::string method)
+        = 0;
+    virtual ~MessageBus() { }
+};

--- a/include/testing/test_message_bus.h
+++ b/include/testing/test_message_bus.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cloysterhpc/messagebus.h>
+#include <any>
+#include <tuple>
+#include <vector>
+#include <string>
+
+class TestMessageMethod;
+
+using FunctionStore = std::tuple<std::string, std::string>;
+using FunctionParameters = std::vector<std::any>;
+
+class TestMessageBus : public MessageBus {
+  friend class TestMessageMethod;
+
+private:
+  std::unordered_map<std::string, std::vector<FunctionParameters>> m_functions;
+
+  std::string makeStoreName(FunctionStore s) const {
+    return std::get<0>(s) + "->" + std::get<1>(s);
+  }
+
+  void registerCall(FunctionStore s, FunctionParameters p) {
+    auto count = this->callCount(s);
+    m_functions[makeStoreName(s)].push_back(p);
+  }
+
+public:
+  std::unique_ptr<MessageBusMethod> method(std::string interface,
+                                           std::string method);
+
+  void dump() const;
+
+  unsigned callCount(FunctionStore s) const;
+  FunctionParameters calledWith(FunctionStore s, unsigned index) const;
+};
+
+class TestMessageMethod : public MessageBusMethod {
+private:
+  TestMessageBus *m_bus;
+  FunctionStore m_store;
+  FunctionParameters m_params = {};
+
+protected:
+  virtual void pushSingleParam(MethodParamVariant param) {
+    std::visit([this](auto &&arg) { this->m_params.push_back(arg); }, param);
+  }
+  virtual MessageReply callMethod();
+
+public:
+  TestMessageMethod(TestMessageBus *bus, FunctionStore s)
+      : m_bus(bus), m_store(s) {}
+};

--- a/src/daemon_handler.cpp
+++ b/src/daemon_handler.cpp
@@ -1,0 +1,96 @@
+#include <cloysterhpc/daemon_handler.h>
+
+std::string DaemonHandler::fixServiceName(std::string name)
+{
+    if (!name.ends_with(".service")) {
+        return name + ".service";
+    } else {
+        return name;
+    }
+}
+
+bool DaemonHandler::exists()
+{
+    auto path = this->callObjectFunction("GetUnit");
+    return path.size() > 0;
+}
+
+void DaemonHandler::start()
+{
+    this->callObjectFunction("StartUnit", "replace");
+}
+
+void DaemonHandler::stop() { this->callObjectFunction("StopUnit", "replace"); }
+
+void DaemonHandler::load() { this->callObjectFunction("LoadUnit"); }
+
+void DaemonHandler::restart()
+{
+    this->callObjectFunction("RestartUnit", "replace");
+}
+
+void DaemonHandler::daemonReload(MessageBus& bus)
+{
+    bus.method("org.freedesktop.systemd1.Manager", "Reload")->call();
+}
+
+#ifdef BUILD_TESTING
+#include <doctest/doctest.h>
+#else
+#define DOCTEST_CONFIG_DISABLE
+#include <doctest/doctest.h>
+#endif
+
+#include <testing/test_message_bus.h>
+
+TEST_SUITE("Test service handler connectivity")
+{
+    TEST_CASE("Service handler testing")
+    {
+        auto testBus = std::make_shared<TestMessageBus>();
+
+        DaemonHandler sr { testBus, "generic-service" };
+
+        SUBCASE("it can start")
+        {
+            auto function = std::make_tuple<std::string, std::string>(
+                "org.freedesktop.systemd1.Manager", "StartUnit");
+
+            REQUIRE(testBus->callCount(function) == 0);
+            sr.start();
+
+            REQUIRE(testBus->callCount(function) == 1);
+            auto params = testBus->calledWith(function, 0);
+            CHECK(std::any_cast<std::string>(params[0])
+                == "generic-service.service");
+        }
+
+        SUBCASE("it can stop")
+        {
+            auto function = std::make_tuple<std::string, std::string>(
+                "org.freedesktop.systemd1.Manager", "StopUnit");
+
+            REQUIRE(testBus->callCount(function) == 0);
+            sr.stop();
+
+            REQUIRE(testBus->callCount(function) == 1);
+            auto params = testBus->calledWith(function, 0);
+            CHECK(std::any_cast<std::string>(params[0])
+                == "generic-service.service");
+        }
+
+        SUBCASE("it can restart")
+        {
+            auto function = std::make_tuple<std::string, std::string>(
+                "org.freedesktop.systemd1.Manager", "RestartUnit");
+
+            REQUIRE(testBus->callCount(function) == 0);
+            sr.restart();
+
+            REQUIRE(testBus->callCount(function) == 1);
+            auto params = testBus->calledWith(function, 0);
+            CHECK(std::any_cast<std::string>(params[0])
+                == "generic-service.service");
+        }
+    }
+}

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -181,7 +181,7 @@ address Network::fetchSubnetMask(const std::string& interface)
             LOG_TRACE("Got subnet mask address {} from interface {}",
                 result.to_string(), interface);
 #endif
-
+            freeifaddrs(ifaddr);
             return result;
         }
     }

--- a/src/services/shell.cpp
+++ b/src/services/shell.cpp
@@ -229,8 +229,8 @@ void Shell::disallowSSHRootPasswordLogin()
 {
     LOG_INFO("Allowing root login only through public key authentication (SSH)")
 
-    runCommand("sed -i s/PermitRootLogin\\ yes/PermitRootLogin\\ "
-               "without-password/g /etc/ssh/sshd_config");
+    runCommand("sed -i 's/PermitRootLogin\\ yes/PermitRootLogin\\ "
+               "without-password/g' /etc/ssh/sshd_config");
 }
 
 void Shell::installOpenHPCBase()

--- a/test/test_message_bus.cpp
+++ b/test/test_message_bus.cpp
@@ -1,0 +1,54 @@
+#include <cstdio>
+#include <testing/test_message_bus.h>
+
+unsigned TestMessageBus::callCount(FunctionStore s) const
+{
+    auto sname = makeStoreName(s);
+    if (!m_functions.contains(sname)) {
+        return 0;
+    } else {
+        return m_functions.at(sname).size();
+    }
+}
+
+FunctionParameters TestMessageBus::calledWith(
+    FunctionStore s, unsigned index) const
+{
+    if (this->callCount(s) == 0 || index >= this->callCount(s)) {
+        return {};
+    }
+
+    auto sname = makeStoreName(s);
+    return m_functions.at(sname).at(index);
+}
+
+void TestMessageBus::dump() const
+{
+    fprintf(stderr, "???\n");
+    for (const auto& [k, paramslist] : m_functions) {
+        fprintf(stderr, "\t%s: %ld calls\n", k.c_str(), paramslist.size());
+        int i = 0;
+        for (const auto& params : paramslist) {
+            fprintf(stderr, "\t\t%d: ", i++);
+            for (const auto& p : params) {
+                fprintf(stderr, "<%s> ", p.type().name());
+            }
+            fprintf(stderr, "\n");
+        }
+    }
+}
+
+std::unique_ptr<MessageBusMethod> TestMessageBus::method(
+    std::string interface, std::string method)
+{
+    auto store = std::make_tuple(interface, method);
+    return std::unique_ptr<MessageBusMethod>(
+        new TestMessageMethod { this, store });
+}
+
+MessageReply TestMessageMethod::callMethod()
+{
+    m_bus->registerCall(m_store, m_params);
+    return MessageReply(
+        std::make_any<sdbus::ObjectPath>(sdbus::ObjectPath("123")));
+}


### PR DESCRIPTION
Before, when we needed to manage a daemon, we called systemd using the command line.

This is not good for a series of reasons: complex error handling, depending on the necessary process quota, feeling of sloppiness...

This PR start adding a DBus management class, plus a `DaemonHandler` class, to do all the required tasks.

This also fixes some memory leaks I found

(Note that most operations do not exist, and will be added as required, when we start implementing the `DaemonHandler`. This PR only add sufficient support for us to "start get going")