### PR TITLE
Disable sanitizers on release builds

### DIFF
--- a/cmake/Hardening.cmake
+++ b/cmake/Hardening.cmake
@@ -73,7 +73,7 @@ macro(
   if(${ubsan_minimal_runtime})
     check_cxx_compiler_flag("-fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-minimal-runtime"
                             MINIMAL_RUNTIME)
-    if(MINIMAL_RUNTIME)
+    if(MINIMAL_RUNTIME AND CMAKE_BUILD_TYPE STREQUAL "Debug")
       set(NEW_COMPILE_OPTIONS "${NEW_COMPILE_OPTIONS} -fsanitize=undefined -fsanitize-minimal-runtime")
       set(NEW_LINK_OPTIONS "${NEW_LINK_OPTIONS} -fsanitize=undefined -fsanitize-minimal-runtime")
 
@@ -86,7 +86,7 @@ macro(
 
       message(STATUS "*** ubsan minimal runtime enabled")
     else()
-      message(STATUS "*** ubsan minimal runtime NOT enabled (not supported)")
+      message(STATUS "*** ubsan minimal runtime NOT enabled (not supported or not applicable)")
     endif()
   else()
     message(STATUS "*** ubsan minimal runtime NOT enabled (not requested)")

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -9,8 +9,8 @@ function(
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     set(SANITIZERS "")
-
-    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+ 
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
       message(STATUS, "Release build detected. disabling sanitizers...")
       return()
     endif()

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -10,6 +10,11 @@ function(
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     set(SANITIZERS "")
 
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+      message(STATUS, "Release build detected. disabling sanitizers...")
+      return()
+    endif()
+    
     if(${ENABLE_SANITIZER_ADDRESS})
       list(APPEND SANITIZERS "address")
     endif()

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -11,7 +11,7 @@ function(
     set(SANITIZERS "")
  
     if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-      message(STATUS, "Release build detected. disabling sanitizers...")
+      message(STATUS, "Non debug build detected. disabling sanitizers...")
       return()
     endif()
     

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -11,7 +11,7 @@ function(
     set(SANITIZERS "")
  
     if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-      message(STATUS, "Non debug build detected. disabling sanitizers...")
+      message(STATUS, "Non debug build detected. Disabling sanitizers...")
       return()
     endif()
     


### PR DESCRIPTION
The sanitizers works best on debug builds, they do not make sense on release and add unneeded dependencies