### PR TITLE
[CLOYSTER-109] Implement service network

### DIFF
--- a/example.answerfile.ini
+++ b/example.answerfile.ini
@@ -35,6 +35,16 @@ domain_name=cluster.example.com
 #nameservers=172.26.0.1
 #mac_address=de:ad:be:ff:00:01
 
+# Double-commented options are optional
+#[network_service]
+#interface=enp2s0
+#ip_address=172.26.255.256
+#subnet_mask=255.255.0.0
+##gateway=172.26.0.1
+#domain_name=cluster.example.com
+##nameservers=172.26.0.1
+##mac_address=de:ad:be:ff:00:01
+
 # Use the network_application if using a Infiniband
 # Must inform all options if enabled
 #[network_application]

--- a/include/cloysterhpc/answerfile.h
+++ b/include/cloysterhpc/answerfile.h
@@ -167,6 +167,13 @@ private:
     void loadManagementNetwork();
 
     /**
+     * @brief Loads the service network configuration.
+     *
+     * This function parses and loads the settings for the service network.
+     */
+    void loadServiceNetwork();
+
+    /**
      * @brief Loads the application network configuration.
      *
      * This function parses and loads the settings for the application network.
@@ -269,6 +276,7 @@ public:
     AFNetwork external;
     AFNetwork management;
     AFNetwork application;
+    AFNetwork service;
     AFInformation information;
     AFTime time;
     AFHostname hostname;

--- a/src/answerfile.cpp
+++ b/src/answerfile.cpp
@@ -139,6 +139,14 @@ void AnswerFile::loadManagementNetwork()
     loadNetwork("network_management", management);
 }
 
+void AnswerFile::loadServiceNetwork()
+{
+    if (!m_ini.exists("network_service"))
+        return;
+
+    loadNetwork("network_service", service);
+}
+
 void AnswerFile::loadApplicationNetwork()
 {
     if (!m_ini.exists("network_application"))


### PR DESCRIPTION
This PR implements the _service_ network.

While the `cluster::fillData` function requires refactoring, especially in the network-related areas, I have implemented this without refactoring to make sure we meet our delivery deadline. A new task (CLOYSTER-117) has been created to do this refactoring later.