### PR TITLE
Hotfix: Fix xCAT abort error when getting first node

### DIFF
--- a/include/cloysterhpc/inifile.h
+++ b/include/cloysterhpc/inifile.h
@@ -80,6 +80,15 @@ public:
     std::vector<std::string> listAllEntries(const std::string& section) const;
 
     /**
+     * @brief List all the entries of a section, with a certain prefix, like
+     * "node." for nodes
+     *
+     * @return The names of the entries found
+     */
+    std::vector<std::string> listAllPrefixedEntries(
+        const std::string_view prefix) const;
+
+    /**
      * @brief Sets a value in the INI file.
      *
      * @param section The section in the INI file.

--- a/src/inifile.cpp
+++ b/src/inifile.cpp
@@ -137,6 +137,24 @@ std::vector<std::string> inifile::listAllSections() const
     return convertIniNames(std::move(sections));
 }
 
+/**
+ * @brief List all the entries of a section, with a certain prefix, like
+ * "node." for nodes
+ *
+ * @return The names of the entries found
+ */
+std::vector<std::string> inifile::listAllPrefixedEntries(
+    const std::string_view prefix) const
+{
+    auto vec = listAllSections();
+    std::vector<std::string> filtered;
+
+    std::copy_if(vec.begin(), vec.end(), std::back_inserter(filtered),
+        [prefix](std::string v) { return v.starts_with(prefix); });
+
+    return filtered;
+}
+
 std::vector<std::string> inifile::listAllEntries(
     const std::string& section) const
 {

--- a/src/queuesystem/slurm.cpp
+++ b/src/queuesystem/slurm.cpp
@@ -6,6 +6,7 @@
 #include <cloysterhpc/cluster.h>
 #include <cloysterhpc/queuesystem/slurm.h>
 #include <cloysterhpc/services/log.h>
+#include <filesystem>
 
 using cloyster::runCommand;
 

--- a/src/services/IService.cpp
+++ b/src/services/IService.cpp
@@ -15,7 +15,7 @@ void IService::enable()
 
     if (retvec.empty()) {
         throw std::runtime_error {
-            "Service enable failed, dbus call returned <= 0"
+            "Service enable failed, service not found (service count <= 0)"
         };
     }
 }
@@ -29,7 +29,7 @@ void IService::disable()
 
     if (ret.empty()) {
         throw std::runtime_error {
-            "Service disable failed, dbus call returned <= 0"
+            "Service disable failed, service not found (service count <= 0)"
         };
     }
 }

--- a/test/sample/answerfile/unordered.answerfile.ini
+++ b/test/sample/answerfile/unordered.answerfile.ini
@@ -1,0 +1,87 @@
+# Example answerfile model to use with Cloyster.
+
+[information]
+cluster_name=cloyster
+company_name=cloyster-enterprises
+administrator_email=foo@example.com
+
+[time]
+timezone=America/Sao_Paulo
+timeserver=0.br.pool.ntp.org
+locale=en_US.utf8
+
+[hostname]
+hostname=cloyster
+domain_name=cluster.example.com
+
+# Cloyster must have an external network
+[network_external]
+interface=eth1
+#ip_address=172.16.144.0
+#subnet_mask=255.255.255.0
+#gateway=192.168.122.1
+domain_name=cluster.external.example.com
+#nameservers=146.164.36.7,146.164.36.15
+#mac_address=de:ad:be:ff:00:00
+
+# Cloyster must have an management network
+[network_management]
+interface=eth2
+ip_address=172.26.30.10
+subnet_mask=255.255.255.0
+#gateway=172.26.0.1
+domain_name=cluster.management.example.com
+#nameservers=172.26.0.1
+#mac_address=de:ad:be:ff:00:01
+
+# Use the network_application if using a Infiniband
+# Must inform all options if enabled
+#[network_application]
+#interface=ib0
+#ip_address=172.26.0.0
+#subnet_mask=255.255.0.0
+#gateway=0.0.0.0
+#domain_name=cloysterhpc.example
+#nameservers=0.0.0.0,0.0.0.0
+#mac_address=de:ad:be:ff:00:01
+
+[system]
+# Full path to the disk image
+disk_image=/opt/iso/rhel-9.3-x86_64-dvd.iso
+# Supported distros: rhel, ol, rocky
+distro=rhel
+version=9.3
+kernel=4.18.0-513.5.1.el8_9.x86_64
+
+# Generic. If a node.XX section does not have one of these options, they are obtained here.
+# Comment if you don't want to use generic options. In this case, you MUST fulfill all the node.XX options.
+# These options MUST exist, either specifically in the node.XX sections or in the generic section [node].
+[node]
+prefix=n
+padding=2
+node_ip=172.26.0.1
+node_root_password=pwd
+sockets=1
+cores_per_socket=1
+threads_per_core=1
+bmc_username=admin
+bmc_password=admin
+bmc_serialport=0
+bmc_serialspeed=9600
+
+# Uncomment if you want to override any of the [node] options.
+# These options MUST exist, either specifically in the node.XX sections or in the generic section [node].
+[node.2]
+# Hostname is optional. If commented, you MUST specify "prefix" and "padding".
+hostname=foo
+mac_address=ca:fe:de:ad:be:ef
+#node_ip=172.26.0.1
+#node_root_password=pwd
+#sockets=1
+#cores_per_socket=1
+#threads_per_core=1
+bmc_address=10.0.0.2
+#bmc_username=admin
+#bmc_password=admin
+#bmc_serialport=0
+#bmc_serialspeed=9600


### PR DESCRIPTION
This was caused by a failure to parse nodes, because the first node (node.1) was commented in the answerfile.