### PR TITLE
[CLOYSTER-129] Make the configuration reversible, avoid running commands there

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ needed.
 * Adherence with best practices is done
   with [gsl-lite](https://github.com/gsl-lite/gsl-lite).
 * [newt](https://pagure.io/newt) for Terminal UI.
+* [Perl](https://www.perl.org/) for the libxcrypt, one of our
+  subdependencies. The lib (and the one who depend on it) will be
+  removed because this dependency caused a lot of issues
 
 Only [newt](https://pagure.io/newt) must be pre-installed for compilation. We
 don't ship it. Everything else should be found and installed

--- a/include/cloysterhpc/repos.h
+++ b/include/cloysterhpc/repos.h
@@ -75,7 +75,7 @@ private:
     void loadSingleFile(std::filesystem::path source);
     void saveRepositories();
 
-    void configureXCAT();
+    void configureXCAT(const std::filesystem::path& repofile_dest);
     void configureEL();
     void setEnableState(const std::string& id, bool value);
 

--- a/src/diskImage.cpp
+++ b/src/diskImage.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2022 Vinícius Ferrão <vinicius@ferrao.net.br>
  * SPDX-License-Identifier: Apache-2.0

--- a/src/repos.cpp
+++ b/src/repos.cpp
@@ -98,8 +98,20 @@ void RepoManager::loadFiles(const std::filesystem::path& basedir)
     auto cloyster_repos = buildCloysterTree(basedir);
     mergeWithCurrentList(std::move(cloyster_repos));
 
+    auto destparent = std::filesystem::temp_directory_path() / "cloyster0";
+    auto destination = destparent / "yum.repos.d";
+    std::filesystem::create_directory(destparent);
+    std::filesystem::create_directory(destination);
+
     configureEL();
     configureXCAT();
+
+    for (auto const& dir_entry :
+        std::filesystem::directory_iterator { destination }) {
+        const auto path = dir_entry.path();
+        if (path.extension() == ".repo")
+            loadSingleFile(path);
+    }
 }
 
 void RepoManager::loadCustom(inifile& file, const std::filesystem::path& path)
@@ -183,7 +195,15 @@ void RepoManager::configureEL()
 
 void RepoManager::commitStatus()
 {
+    m_runner.executeCommand("dnf -y install initscripts");
     createFileFor("/etc/yum.repos.d/cloyster.repo");
+    auto tmpdir
+        = std::filesystem::temp_directory_path() / "cloyster0/yum.repos.d";
+
+    for (auto const& dir_entry :
+        std::filesystem::directory_iterator { tmpdir }) {
+        std::filesystem::copy(dir_entry, "/etc/yum.repos.d");
+    }
 
     std::vector<std::string> to_enable;
     std::vector<std::string> to_disable;
@@ -291,25 +311,28 @@ static void createGPGKey(
 
 void RepoManager::configureXCAT()
 {
-    LOG_INFO("Setting up XCAT repositories")
+    LOG_INFO("Setting up XCAT repositories");
 
+    auto destination
+        = std::filesystem::temp_directory_path() / "cloyster0" / "yum.repos.d";
+
+    // TODO: we need to download these files in a sort of temporary directory
     m_runner.downloadFile("https://xcat.org/files/xcat/repos/yum/latest/"
                           "xcat-core/xcat-core.repo",
-        "/etc/yum.repos.d");
+        destination.string());
 
     switch (m_os.getPlatform()) {
         case OS::Platform::el8:
             m_runner.downloadFile(
                 "https://xcat.org/files/xcat/repos/yum/devel/xcat-dep/"
                 "rh8/x86_64/xcat-dep.repo",
-                "/etc/yum.repos.d");
+                destination.string());
             break;
         case OS::Platform::el9:
-            m_runner.executeCommand("dnf -y install initscripts");
             m_runner.downloadFile(
                 "https://xcat.org/files/xcat/repos/yum/devel/xcat-dep/"
                 "rh9/x86_64/xcat-dep.repo",
-                "/etc/yum.repos.d");
+                destination.string());
             break;
         default:
             throw std::runtime_error("Unsupported platform for xCAT");

--- a/src/repos.cpp
+++ b/src/repos.cpp
@@ -79,6 +79,8 @@ static void loadFromINI(const std::filesystem::path& source, inifile& file,
     }
 }
 
+#define NOSONAR(code) code
+
 void RepoManager::loadSingleFile(std::filesystem::path source)
 {
     inifile file;
@@ -98,7 +100,8 @@ void RepoManager::loadFiles(const std::filesystem::path& basedir)
     auto cloyster_repos = buildCloysterTree(basedir);
     mergeWithCurrentList(std::move(cloyster_repos));
 
-    auto destparent = std::filesystem::temp_directory_path() / "cloyster0";
+    auto destparent
+        = NOSONAR(std::filesystem::temp_directory_path()) / "cloyster0";
     auto destination = destparent / "yum.repos.d";
     std::filesystem::create_directory(destparent);
     std::filesystem::create_directory(destination);
@@ -197,8 +200,8 @@ void RepoManager::commitStatus()
 {
     m_runner.executeCommand("dnf -y install initscripts");
     createFileFor("/etc/yum.repos.d/cloyster.repo");
-    auto tmpdir
-        = std::filesystem::temp_directory_path() / "cloyster0/yum.repos.d";
+    auto tmpdir = NOSONAR(std::filesystem::temp_directory_path())
+        / "cloyster0/yum.repos.d";
 
     for (auto const& dir_entry :
         std::filesystem::directory_iterator { tmpdir }) {

--- a/src/repos.cpp
+++ b/src/repos.cpp
@@ -104,7 +104,7 @@ void RepoManager::loadFiles(const std::filesystem::path& basedir)
     std::filesystem::create_directory(destination);
 
     configureEL();
-    configureXCAT();
+    configureXCAT(destination);
 
     for (auto const& dir_entry :
         std::filesystem::directory_iterator { destination }) {
@@ -309,30 +309,27 @@ static void createGPGKey(
     gpgkey.close();
 }
 
-void RepoManager::configureXCAT()
+void RepoManager::configureXCAT(const std::filesystem::path& repofile_dest)
 {
     LOG_INFO("Setting up XCAT repositories");
-
-    auto destination
-        = std::filesystem::temp_directory_path() / "cloyster0" / "yum.repos.d";
 
     // TODO: we need to download these files in a sort of temporary directory
     m_runner.downloadFile("https://xcat.org/files/xcat/repos/yum/latest/"
                           "xcat-core/xcat-core.repo",
-        destination.string());
+        repofile_dest.string());
 
     switch (m_os.getPlatform()) {
         case OS::Platform::el8:
             m_runner.downloadFile(
                 "https://xcat.org/files/xcat/repos/yum/devel/xcat-dep/"
                 "rh8/x86_64/xcat-dep.repo",
-                destination.string());
+                repofile_dest.string());
             break;
         case OS::Platform::el9:
             m_runner.downloadFile(
                 "https://xcat.org/files/xcat/repos/yum/devel/xcat-dep/"
                 "rh9/x86_64/xcat-dep.repo",
-                destination.string());
+                repofile_dest.string());
             break;
         default:
             throw std::runtime_error("Unsupported platform for xCAT");


### PR DESCRIPTION
Avoid running commands before installation; when running them, make them reversible