### PR TITLE
[CLOYSTER-130] Do not allow choosing the internal NIC when selecting the external

### DIFF
--- a/include/cloysterhpc/presenter/PresenterInfiniband.h
+++ b/include/cloysterhpc/presenter/PresenterInfiniband.h
@@ -27,8 +27,8 @@ private:
     };
 
 public:
-    PresenterInfiniband(
-        std::unique_ptr<Cluster>& model, std::unique_ptr<Newt>& view);
+    PresenterInfiniband(std::unique_ptr<Cluster>& model,
+        std::unique_ptr<Newt>& view, NetworkCreator& nc);
 };
 
 #endif // CLOYSTERHPC_PRESENTERINFINIBAND_H_

--- a/include/cloysterhpc/presenter/PresenterNetwork.h
+++ b/include/cloysterhpc/presenter/PresenterNetwork.h
@@ -119,7 +119,10 @@ private:
     }
 #endif
 
-    void createNetwork(NetworkCreatorData& ncd);
+    std::vector<std::string> retrievePossibleInterfaces(NetworkCreator& nc);
+
+    void createNetwork(
+        const std::vector<std::string>& interfaceList, NetworkCreatorData& ncd);
 
 public:
     PresenterNetwork(std::unique_ptr<Cluster>& model,

--- a/include/cloysterhpc/presenter/PresenterNetwork.h
+++ b/include/cloysterhpc/presenter/PresenterNetwork.h
@@ -8,6 +8,7 @@
 
 #include <cloysterhpc/presenter/Presenter.h>
 
+#include <boost/asio.hpp>
 #include <cloysterhpc/cluster.h>
 #include <cloysterhpc/network.h>
 #include <cloysterhpc/services/log.h>
@@ -18,10 +19,34 @@
 #include <memory>
 #include <utility>
 
+struct NetworkCreatorData {
+    Network::Profile profile;
+    Network::Type type;
+    std::string interface;
+    std::string address;
+    std::string subnetMask;
+    std::string gateway;
+    std::string name;
+    std::vector<boost::asio::ip::address> domains;
+};
+
+class NetworkCreator {
+private:
+    std::vector<NetworkCreatorData> m_networks;
+
+    bool checkIfProfileExists(Network::Profile profile);
+
+public:
+    bool addNetworkInformation(NetworkCreatorData&& data);
+
+    bool checkIfInterfaceRegistered(std::string_view interface);
+
+    void saveNetworksToModel(Cluster& model);
+};
+
 class PresenterNetwork : public Presenter {
 private:
     std::unique_ptr<Network> m_network;
-    Connection m_connection;
 
     struct Messages {
         static constexpr const auto title = "Network Settings";
@@ -94,11 +119,11 @@ private:
     }
 #endif
 
-    void createNetwork();
+    void createNetwork(NetworkCreatorData& ncd);
 
 public:
     PresenterNetwork(std::unique_ptr<Cluster>& model,
-        std::unique_ptr<Newt>& view,
+        std::unique_ptr<Newt>& view, NetworkCreator& nc,
         Network::Profile profile = Network::Profile::External,
         Network::Type type = Network::Type::Ethernet);
 };

--- a/include/cloysterhpc/services/shell.h
+++ b/include/cloysterhpc/services/shell.h
@@ -73,6 +73,8 @@ private:
      */
     void disableNetworkManagerDNSOverride(); // This should be on Network
 
+    void deleteConnectionIfExists(std::string_view connectionName);
+
     /**
      * @brief Configures network connections.
      *

--- a/src/presenter/PresenterInfiniband.cpp
+++ b/src/presenter/PresenterInfiniband.cpp
@@ -7,8 +7,8 @@
 
 #include <algorithm>
 
-PresenterInfiniband::PresenterInfiniband(
-    std::unique_ptr<Cluster>& model, std::unique_ptr<Newt>& view)
+PresenterInfiniband::PresenterInfiniband(std::unique_ptr<Cluster>& model,
+    std::unique_ptr<Newt>& view, NetworkCreator& nc)
     : Presenter(model, view)
 {
 
@@ -26,13 +26,13 @@ PresenterInfiniband::PresenterInfiniband(
         m_model->setOFED(magic_enum::enum_cast<OFED::Kind>(
             m_view->listMenu(Messages::title, Messages::OFED::question,
                 magic_enum::enum_names<OFED::Kind>(), Messages::OFED::help))
-                             .value());
+                .value());
         LOG_DEBUG("Set OFED stack as: {}",
             magic_enum::enum_name<OFED::Kind>(m_model->getOFED()->getKind()));
 
         try {
             Call<PresenterNetwork>(
-                Network::Profile::Application, Network::Type::Infiniband);
+                nc, Network::Profile::Application, Network::Type::Infiniband);
         } catch (const std::exception& ex) {
             LOG_ERROR("Failed to add {} network: {}",
                 magic_enum::enum_name(Network::Profile::Application),

--- a/src/presenter/PresenterInfiniband.cpp
+++ b/src/presenter/PresenterInfiniband.cpp
@@ -26,7 +26,7 @@ PresenterInfiniband::PresenterInfiniband(std::unique_ptr<Cluster>& model,
         m_model->setOFED(magic_enum::enum_cast<OFED::Kind>(
             m_view->listMenu(Messages::title, Messages::OFED::question,
                 magic_enum::enum_names<OFED::Kind>(), Messages::OFED::help))
-                .value());
+                             .value());
         LOG_DEBUG("Set OFED stack as: {}",
             magic_enum::enum_name<OFED::Kind>(m_model->getOFED()->getKind()));
 

--- a/src/presenter/PresenterInstall.cpp
+++ b/src/presenter/PresenterInstall.cpp
@@ -53,7 +53,7 @@ PresenterInstall::PresenterInstall(
     //  the lazy network{1,2} after that.
 
     try {
-        Call<PresenterNetwork>(nc);
+        Call<PresenterNetwork>(nc, Network::Profile::External);
     } catch (const std::exception& ex) {
         LOG_ERROR("Failed to add {} network: {}",
             magic_enum::enum_name(Network::Profile::External), ex.what());
@@ -61,7 +61,6 @@ PresenterInstall::PresenterInstall(
 
     try {
         Call<PresenterNetwork>(nc, Network::Profile::Management);
-        // PresenterNetwork network(model, view, Network::Profile::Management);
     } catch (const std::exception& ex) {
         LOG_ERROR("Failed to add {} network: {}",
             magic_enum::enum_name(Network::Profile::Management), ex.what());

--- a/src/presenter/PresenterInstall.cpp
+++ b/src/presenter/PresenterInstall.cpp
@@ -45,6 +45,7 @@ PresenterInstall::PresenterInstall(
     Call<PresenterRepository>();
 #endif
 
+    NetworkCreator nc;
 #if 1 // Networking
     // TODO: Under development
     //  * Add it to a loop where it asks to the user which kind of network we
@@ -52,24 +53,26 @@ PresenterInstall::PresenterInstall(
     //  the lazy network{1,2} after that.
 
     try {
-        Call<PresenterNetwork>();
+        Call<PresenterNetwork>(nc);
     } catch (const std::exception& ex) {
         LOG_ERROR("Failed to add {} network: {}",
             magic_enum::enum_name(Network::Profile::External), ex.what());
     }
 
     try {
-        Call<PresenterNetwork>(Network::Profile::Management);
+        Call<PresenterNetwork>(nc, Network::Profile::Management);
         // PresenterNetwork network(model, view, Network::Profile::Management);
     } catch (const std::exception& ex) {
         LOG_ERROR("Failed to add {} network: {}",
             magic_enum::enum_name(Network::Profile::Management), ex.what());
     }
+
 #endif
 
 #if 1 // Infiniband support
-    Call<PresenterInfiniband>();
+    Call<PresenterInfiniband>(nc);
 #endif
+    nc.saveNetworksToModel(*m_model);
 
 #if 1 // Compute nodes formation details
     Call<PresenterNodesOperationalSystem>();

--- a/src/presenter/PresenterNetwork.cpp
+++ b/src/presenter/PresenterNetwork.cpp
@@ -6,6 +6,80 @@
 #include <boost/algorithm/string.hpp>
 #include <cloysterhpc/presenter/PresenterNetwork.h>
 
+// Maybe a central NetworkCreator class can be added here?
+// The PresenterNetwork receives the NetworkCreator alongside both parameters,
+// and just add them to the NetworkInfo. After that, the NetworkInfo, with
+// proper methods, adds them to the model
+
+#include <algorithm>
+
+bool NetworkCreator::checkIfProfileExists(Network::Profile profile)
+{
+    namespace ranges = std::ranges;
+    if (auto it = ranges::find_if(
+            m_networks, [profile](auto& n) { return n.profile == profile; });
+        it != m_networks.end()) {
+        return true;
+    }
+
+    return false;
+}
+
+bool NetworkCreator::addNetworkInformation(NetworkCreatorData&& data)
+{
+    if (checkIfProfileExists(data.profile)) {
+        return false;
+    }
+
+    m_networks.push_back(data);
+    return true;
+}
+
+bool NetworkCreator::checkIfInterfaceRegistered(std::string_view interface)
+{
+    namespace ranges = std::ranges;
+    if (auto it = ranges::find_if(m_networks,
+            [interface](auto& n) { return n.interface == interface; });
+        it != m_networks.end()) {
+        return true;
+    }
+
+    return false;
+}
+
+void NetworkCreator::saveNetworksToModel(Cluster& model)
+{
+    for (const auto& net : m_networks) {
+        auto netptr = std::make_unique<Network>(net.profile, net.type);
+        Connection conn(netptr.get());
+
+        conn.setAddress(net.address);
+        conn.setInterface(net.interface);
+
+        netptr->setSubnetMask(net.subnetMask);
+        netptr->setAddress(netptr->calculateAddress(conn.getAddress()));
+        netptr->setGateway(net.gateway);
+        netptr->setDomainName(net.name);
+        netptr->setNameservers(net.domains);
+
+        LOG_TRACE("Moved m_network and m_connection into m_model")
+        model.addNetwork(std::move(netptr));
+        model.getHeadnode().addConnection(std::move(conn));
+
+        // Check moved data
+        LOG_DEBUG("Added {} connection on headnode: {} -> {}",
+            magic_enum::enum_name(net.profile),
+            model.getHeadnode()
+                .getConnection(net.profile)
+                .getInterface()
+                .value(),
+            model.getHeadnode()
+                .getConnection(net.profile)
+                .getAddress()
+                .to_string());
+    }
+}
+
 // FIXME: I don't like this code, it's ugly.
 //  *** The following ideas were implemented, although not properly tested, so
 //  *** we leave this comment here.
@@ -16,23 +90,26 @@
 //  be called, leaving garbage on the model.
 //  * Try and catch blocks should be added to avoid all those conditions.
 //
+// Most of issues above are being solved:
+//  - we moved the network/connection addition to later, after we destroy
+//    this class. We move the data using the NetworkCreator class, and create
+//    things there.
+//
 // TODO: Just an idea, instead of undoing changes on the model, we may
 //  instantiate a Network and a Connection object and after setting up it's
 //  attributes we just copy them to the right place or even better, we move it.
 //  After the end of this class the temporary objects will be destroyed anyway.
 
 PresenterNetwork::PresenterNetwork(std::unique_ptr<Cluster>& model,
-    std::unique_ptr<Newt>& view, Network::Profile profile, Network::Type type)
+    std::unique_ptr<Newt>& view, NetworkCreator& nc, Network::Profile profile,
+    Network::Type type)
     : Presenter(model, view)
     , m_network(std::make_unique<Network>(profile, type))
-    , m_connection(m_network.get())
 {
-    LOG_DEBUG("Added {} network with type {}",
-        magic_enum::enum_name(m_network->getProfile()),
-        magic_enum::enum_name(m_network->getType()));
+    LOG_DEBUG("Added {} network with type {}", magic_enum::enum_name(profile),
+        magic_enum::enum_name(type));
 
-    LOG_DEBUG("Added connection to {} network",
-        magic_enum::enum_name(m_connection.getNetwork()->getProfile()));
+    LOG_DEBUG("Added connection to {} network", magic_enum::enum_name(profile));
 
     // TODO: This should be on the header and be constexpr (if possible)
     m_view->message(Messages::title,
@@ -41,10 +118,14 @@ PresenterNetwork::PresenterNetwork(std::unique_ptr<Cluster>& model,
             magic_enum::enum_name(profile), magic_enum::enum_name(type))
             .c_str());
 
-    createNetwork();
+    NetworkCreatorData ncd;
+    ncd.type = type;
+    ncd.profile = profile;
+    createNetwork(ncd);
+    nc.addNetworkInformation(std::move(ncd));
 }
 
-void PresenterNetwork::createNetwork()
+void PresenterNetwork::createNetwork(NetworkCreatorData& ncd)
 {
     // Get the network interface
     const auto& aux = Connection::fetchInterfaces();
@@ -53,8 +134,7 @@ void PresenterNetwork::createNetwork()
         m_view->fatalMessage(Messages::title, Messages::errorInsufficient);
     }
 
-    const auto& interface = networkInterfaceSelection(aux);
-    m_connection.setInterface(interface);
+    std::string interface = networkInterfaceSelection(aux);
 
     std::vector<address> nameservers = Network::fetchNameservers();
     std::vector<std::string> formattedNameservers;
@@ -83,28 +163,13 @@ void PresenterNetwork::createNetwork()
 
     // Set the gathered data
     std::size_t i = 0;
-    m_connection.setAddress(networkDetails[i++].second);
-    m_network->setSubnetMask(networkDetails[i++].second);
-    m_network->setAddress(
-        m_network->calculateAddress(m_connection.getAddress()));
-    m_network->setGateway(networkDetails[i++].second);
+
+    ncd.interface = interface;
+    ncd.address = networkDetails[i++].second;
+    ncd.subnetMask = networkDetails[i++].second;
+    ncd.gateway = networkDetails[i++].second;
 
     // Domain Data
-    m_network->setDomainName(networkDetails[i++].second);
-
-    m_network->setNameservers(nameservers); // TODO: std::move
-
-    [[maybe_unused]] const auto& profile = m_network->getProfile();
-
-    // Move the data
-    m_model->addNetwork(std::move(m_network));
-    LOG_TRACE("Hopefully we have moved m_network to m_model")
-    m_model->getHeadnode().addConnection(std::move(m_connection));
-    LOG_TRACE("Hopefully we have moved m_connection to m_model")
-
-    // Check moved data
-    LOG_DEBUG("Added {} connection on headnode: {} -> {}",
-        magic_enum::enum_name(profile),
-        m_model->getHeadnode().getConnection(profile).getInterface().value(),
-        m_model->getHeadnode().getConnection(profile).getAddress().to_string());
+    ncd.name = networkDetails[i++].second;
+    ncd.domains = nameservers;
 }

--- a/src/services/shell.cpp
+++ b/src/services/shell.cpp
@@ -164,6 +164,11 @@ void Shell::disableNetworkManagerDNSOverride()
     runCommand("systemctl restart NetworkManager");
 }
 
+void Shell::deleteConnectionIfExists(std::string_view connectionName)
+{
+    runCommand(fmt::format("nmcli connection delete \"{}\"", connectionName));
+}
+
 /* This function configure host networks at once with NetworkManager.
  * We enforce that NM is running enabling it with --now and then set default
  * settings and addresses based on data available on the model.
@@ -190,6 +195,8 @@ void Shell::configureNetworks(const std::list<Connection>& connections)
             formattedNameservers.emplace_back(nameservers[i].to_string());
         }
 
+        deleteConnectionIfExists(
+            magic_enum::enum_name(connection.getNetwork()->getProfile()));
         runCommand(fmt::format("nmcli device set {} managed yes", interface));
         runCommand(
             fmt::format("nmcli device set {} autoconnect yes", interface));


### PR DESCRIPTION
Remove the selected internal NIC when presenting a list of possible external interfaces.

Also remove the act of selecting an interface (and filling the parameters) from saving them to the model, to allow a better error handling later.

Also remove conflicts that happen when we run the software twice, of connections already existing, by deleting the old before creating the new one.