### PR TITLE
RPM Build script && Use host glibmm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ cmake_minimum_required(VERSION 3.26.5)
 # so that it works well with tools like CPM or other
 # manual dependency management
 
+# Load PkgConfig so we can use pkg_check_modules later
+# to find local packages.
+find_package(PkgConfig REQUIRED)
+
 # Only set the cxx_standard if it is not set by someone else
 if (NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 23)

--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -86,14 +86,6 @@ function(cloysterhpc_setup_dependencies)
     endif()
   endif()
 
-  if(NOT TARGET glibmm::glibmm)
-    if (cloysterhpc_ENABLE_CONAN)
-      CPMFindPackage(NAME glibmm)
-    else()
-      CPMAddPackage("gh:GNOME/glibmm@2.78.1")
-    endif()
-  endif()
-
   if(NOT TARGET SDBusCpp::sdbus-c++)
     if (cloysterhpc_ENABLE_CONAN)
       CPMFindPackage(NAME sdbus-c++)
@@ -123,11 +115,27 @@ function(cloysterhpc_setup_dependencies)
   endif()
 
   # Standalone packages
+  include(FindPackageHandleStandardArgs)
+
   # Include module path for packages that we need to find or build
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
   include(cmake/Findnewt.cmake)
   if(NOT TARGET newt)
     CPMFindPackage(NAME newt)
+  endif()
+
+  if(NOT TARGET glibmm)
+    pkg_check_modules(GLIBMM REQUIRED glibmm-2.4)
+
+    message(STATUS "GLIBMM_LIBRARIES=${GLIBMM_LIBRARIES}")
+    message(STATUS "GLIBMM_INCLUDE_DIRS=${GLIBMM_INCLUDE_DIRS}")
+    find_package_handle_standard_args(glibmm
+      DEFAULT_MSG
+      GLIBMM_LIBRARIES
+      GLIBMM_INCLUDE_DIRS)
+
+    mark_as_advanced(GLIBMM_INCLUDE_DIRS GLIBMM_LIBRARIES)
+    # include_directories(${GLIBMM_INCLUDE_DIRS})
   endif()
 
   # Set the variable ${STDC++FS} to the correct library

--- a/buildrpm.sh
+++ b/buildrpm.sh
@@ -1,9 +1,40 @@
 #!/bin/bash -eu
 
+function check_build_distro() {
+    local SUPPORTED_BUILD_DISTS=(rocky)
+    local ID=$(awk -F= '/^ID=/ { gsub("\"" , "", $2); print $2}' /etc/os-release)
+    case "${SUPPORTED_BUILD_DISTS[*]}" in
+        "${ID}")
+            ;;
+        *)
+            echo "Build RPM Environment not supported, you need to run this" \
+              "in one of these distros: ${SUPPORTED_BUILD_DISTS}"
+            exit -1
+            ;;
+    esac
+}
+
+function check_rpmbuild_installed() {
+    if ! rpm -q rpmdevtools; then
+        sudo dnf -y install rpmdevtools;
+        rpmdev-setuptree;
+    fi
+}
+
+function check_rpmbuild_init() {
+    if [ ! -d ~/rpmbuild/SOURCES ]; then
+        rpmdev-setuptree
+    fi
+}
+
+check_build_distro
+check_rpmbuild_installed
+check_rpmbuild_init
+
 VERSION=$(awk '/Version:/ {print $2}' rpmspecs/opencattus.spec)
 cp rpmspecs/opencattus.spec ~/rpmbuild/SPECS/
 git archive -o ~/rpmbuild/SOURCES/opencattus-${VERSION}.tar.gz \
-	--format tgz HEAD --prefix opencattus-${VERSION}/ 
+    --format tgz HEAD --prefix opencattus-${VERSION}/
 rpmbuild -ba ~/rpmbuild/SPECS/opencattus.spec
 echo "RPM Generated"
 ls -l ~/rpmbuild/RPMS/*/opencattus-installer*.rpm

--- a/buildrpm.sh
+++ b/buildrpm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+
+VERSION=$(awk '/Version:/ {print $2}' rpmspecs/opencattus.spec)
+cp rpmspecs/opencattus.spec ~/rpmbuild/SPECS/
+git archive -o ~/rpmbuild/SOURCES/opencattus-${VERSION}.tar.gz \
+	--format tgz HEAD --prefix opencattus-${VERSION}/ 
+rpmbuild -ba ~/rpmbuild/SPECS/opencattus.spec
+echo "RPM Generated"
+ls -l ~/rpmbuild/RPMS/*/opencattus-installer*.rpm

--- a/cmake/CommonLibraries.cmake
+++ b/cmake/CommonLibraries.cmake
@@ -9,7 +9,7 @@ set(COMMON_LIBS
         Boost::thread
         spdlog::spdlog
         gsl::gsl-lite
-        glibmm::glibmm
+        ${GLIBMM_LIBRARIES}
         magic_enum::magic_enum
         SimpleIni::SimpleIni
         resolv

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,5 @@
 from conan import ConanFile
 from conan.tools.cmake import cmake_layout, CMakeToolchain, CMake
-from conan.tools.gnu import PkgConfigDeps
 
 class MyProjectConan(ConanFile):
     name = "CloysterHPC"
@@ -8,7 +7,6 @@ class MyProjectConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
 
     def requirements(self):
-        self.tool_requires("pkgconf/1.9.3")  # Ensure pkg-config is available
         self.requires("cli11/[>=2.4.0 <2.5.0]")
         self.requires("spdlog/[>=1.14.0 <1.15.0]")
         self.requires("fmt/[>=10.0.0 <12.0.0]")
@@ -17,6 +15,8 @@ class MyProjectConan(ConanFile):
         self.requires("gsl-lite/[>=0.41.0 <0.42.0]")
         self.requires("doctest/[>=2.4.0 <2.5.0]")
         self.requires("sdbus-cpp/[>=2.0.0 <2.1.0]")
+
+        # We're using host's glibmm
         # self.requires("glibmm/[>=2.78.1 <2.79.0]")
 
         # Override libmount to unify on 2.39.2.
@@ -31,8 +31,6 @@ class MyProjectConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.generate()
-        pkg = PkgConfigDeps(self)
-        pkg.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,13 +1,14 @@
 from conan import ConanFile
 from conan.tools.cmake import cmake_layout, CMakeToolchain, CMake
+from conan.tools.gnu import PkgConfigDeps
 
 class MyProjectConan(ConanFile):
     name = "CloysterHPC"
     version = "0.1.1"
-
     settings = "os", "arch", "compiler", "build_type"
 
     def requirements(self):
+        self.tool_requires("pkgconf/1.9.3")  # Ensure pkg-config is available
         self.requires("cli11/[>=2.4.0 <2.5.0]")
         self.requires("spdlog/[>=1.14.0 <1.15.0]")
         self.requires("fmt/[>=10.0.0 <12.0.0]")
@@ -16,7 +17,7 @@ class MyProjectConan(ConanFile):
         self.requires("gsl-lite/[>=0.41.0 <0.42.0]")
         self.requires("doctest/[>=2.4.0 <2.5.0]")
         self.requires("sdbus-cpp/[>=2.0.0 <2.1.0]")
-        self.requires("glibmm/[>=2.78.1 <2.79.0]")
+        # self.requires("glibmm/[>=2.78.1 <2.79.0]")
 
         # Override libmount to unify on 2.39.2.
         # This prevents the conflict with glib and sdbus-cpp requirements.
@@ -30,6 +31,8 @@ class MyProjectConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.generate()
+        pkg = PkgConfigDeps(self)
+        pkg.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/include/cloysterhpc/functions.h
+++ b/include/cloysterhpc/functions.h
@@ -5,12 +5,10 @@
 #include <boost/process/child.hpp>
 #include <boost/process/pipe.hpp>
 #include <cloysterhpc/services/repos.h>
-#include <concepts>
 #include <filesystem>
-#include <glibmm/ustring.h>
+// #include <glibmm/ustring.h>
 #include <list>
 #include <optional>
-#include <ranges>
 #include <string>
 
 #include <boost/asio.hpp>

--- a/include/cloysterhpc/functions.h
+++ b/include/cloysterhpc/functions.h
@@ -6,7 +6,6 @@
 #include <boost/process/pipe.hpp>
 #include <cloysterhpc/services/repos.h>
 #include <filesystem>
-// #include <glibmm/ustring.h>
 #include <list>
 #include <optional>
 #include <string>

--- a/include/cloysterhpc/services/files.h
+++ b/include/cloysterhpc/services/files.h
@@ -91,6 +91,10 @@ static_assert(cloyster::concepts::IsSaveable<KeyFile>);
 static_assert(concepts::IsMoveable<KeyFile>);
 static_assert(!concepts::IsCopyable<KeyFile>);
 
+
+std::string checksum(const std::string& data);
+std::string checksum(const std::filesystem::path& path, const std::size_t chunkSize = 16384);
+
 };
 
 #endif

--- a/rpmspecs/opencattus.spec
+++ b/rpmspecs/opencattus.spec
@@ -1,0 +1,40 @@
+Name: opencattus-installer 
+Version: 1.0
+Release: 1
+Summary: OpenCATTUS Installer
+License: Apache 2.0
+URL: https://versatushpc.com.br/opencattus/
+Source0: opencattus-%{VERSION}.tar.gz
+BuildRequires: make,cmake,cppcheck,ninja-build,newt-devel,gcc-toolset-14,gcc-toolset-14-libubsan-devel,gcc-toolset-14-libasan-devel
+Requires: newt
+
+# Disable debug package for now
+%global _enable_debug_package 0
+%global debug_package %{nil}
+
+%description
+Use OpenCATTUS installer to setup a HPC cluster from scratch.
+
+%prep
+echo "PREP: $PWD"
+%autosetup -n opencattus-%{VERSION}
+bash -c '
+	source rhel-gcc-toolset-14.sh;
+	cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -G Ninja
+'
+
+%build
+echo "BUILD: $PWD"
+cmake --build build
+
+%install
+echo "INSTALL: $PWD"
+mkdir -p %{buildroot}/usr/bin
+install -m 755 build/src/cloysterhpc %{buildroot}/usr/bin/cloysterhpc
+
+%files
+/usr/bin/cloysterhpc
+
+%changelog
+* Tue Feb 25 2025 Daniel Hilst <danielhilst@versatushpc.com> - 1.0-1
+- Initial release

--- a/setupDevEnvironment.sh
+++ b/setupDevEnvironment.sh
@@ -123,10 +123,12 @@ case "$os_version" in
     ;;
   9)
     dnf -y install python pip libasan libubsan gcc-toolset-14 \
-      gcc-toolset-14-libubsan-devel gcc-toolset-14-libasan-devel cppcheck
+      gcc-toolset-14-libubsan-devel gcc-toolset-14-libasan-devel cppcheck \
+      glibmm24 glibmm24-devel
     ;;
   10)
-    dnf -y install python pip libubsan libasan liblsan libtsan libhwasan
+    dnf -y install python pip libubsan libasan liblsan libtsan libhwasan \
+      glibmm-2.68 glibmm-2.68-devel
     ;;
 esac
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,10 @@ target_link_system_libraries(
 
 # Build a library and a ${cloysterhpc_BINARY_NAME} binary that links to the library
 add_library(cloysterhpc_object OBJECT ${SOURCE_FILES})
+
+# Include glibmm headers as SYSTEM header to avoid warnings
+target_include_directories(cloysterhpc_object SYSTEM PRIVATE ${GLIBMM_INCLUDE_DIRS})
+
 # add_library(cloysterhpc_static STATIC $<TARGET_OBJECTS:cloysterhpc_object>)
 add_library(cloysterhpc_static STATIC $<TARGET_OBJECTS:cloysterhpc_object> $<TARGET_OBJECTS:cloysterhpc_presenter_object>)
 add_executable(${cloysterhpc_BINARY_NAME} main.cpp)

--- a/src/diskImage.cpp
+++ b/src/diskImage.cpp
@@ -10,11 +10,12 @@
 #include <cloysterhpc/services/log.h>
 #include <cstddef>
 #include <fstream>
-#include <glibmm/checksum.h>
 #include <ios>
 #include <istream>
 #include <unordered_map>
 #include <vector>
+
+#include <glibmm.h>
 
 // @FIXME: This file need some work
 //
@@ -108,7 +109,7 @@ bool DiskImage::hasVerifiedChecksum(const std::filesystem::path& path)
             "e" }
     };
 
-    Glib::Checksum checksum(Glib::Checksum::Type::SHA256);
+    Glib::Checksum checksum(Glib::Checksum::ChecksumType::CHECKSUM_SHA256);
 
     std::ifstream file(path, std::ios::in | std::ios::binary);
     if (!file.is_open()) {
@@ -122,14 +123,14 @@ bool DiskImage::hasVerifiedChecksum(const std::filesystem::path& path)
 
     while (file.read(reinterpret_cast<std::istream::char_type*>(buffer.data()),
         static_cast<std::streamsize>(buffer.size()))) {
-        std::streamsize bytesRead = file.gcount();
+        auto bytesRead = static_cast<gsize>(file.gcount());
 
         checksum.update(
             reinterpret_cast<const unsigned char*>(buffer.data()), bytesRead);
     }
 
     // Handle any leftover bytes after the while loop ends
-    std::streamsize bytesRead = file.gcount();
+    auto bytesRead = static_cast<gsize>(file.gcount());
     if (bytesRead > 0) {
         checksum.update(
             reinterpret_cast<const unsigned char*>(buffer.data()), bytesRead);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,9 +6,6 @@
 #include <cctype>
 #include <cstdlib>
 
-#include <glibmm/fileutils.h>
-#include <glibmm/keyfile.h>
-
 #include <CLI/CLI.hpp>
 #include <cloysterhpc/cloyster.h>
 #include <cloysterhpc/const.h>

--- a/src/models/cluster.cpp
+++ b/src/models/cluster.cpp
@@ -400,8 +400,7 @@ void Cluster::fillTestData()
     setProvisioner(Provisioner::xCAT);
 
     setDiskImage("/root/OracleLinux-R8-U5-x86_64-dvd.iso");
-    OS nodeOS(OS::Arch::x86_64, OS::Family::Linux, OS::Platform::el8,
-        OS::Distro::OL, "5.4.17-2136.302.6.1.el8uek.x86_64", 8, 5);
+    OS nodeOS;
     CPU nodeCPU(2, 4, 2);
 
     // TODO: Pass network connection as object


### PR DESCRIPTION
Add a small script and a .spec file to generate the RPM 

-- Edit --

* glibmm was linking dynamically from connan
* The problem is that the generated rpm cannot depend on connan shared objects because they will not exist in the host (if the tool wasn't built there)
* To solve this, we have to link against host's glibmm
* To do that, I load pkg-config module into cmake before conan
* And use it to find glibmm-2.4
* I decided to test with RHEL10, and the build fails because glibmm is at 2.68 version (we're using 2.66), and pkg-config can't find glibmm-2.4 package. 2.4 was the ABI, which was supposed to be stable, but here we are. All the code depending on glibmm was moved to files.cpp to mitigate the problem and should be kept there 
* I added the buildrpm.sh script to generate an RPM in the host, so this is expected to run in the build machine with the proper OS, etc, the rpm is generated at `~/rpmbuild/RPMS/` folder, as usual. The .spec file is not being generated by CPack