### PR TITLE
Fix unreachable code in fetchSubnetMask

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -195,7 +195,6 @@ address Network::fetchSubnetMask(const std::string& interface)
     }
 
     freeifaddrs(ifaddr);
-    return {};
     throw std::runtime_error(fmt::format(
         "Interface {} does not have a netmask address defined", interface));
 }

--- a/test/network.cpp
+++ b/test/network.cpp
@@ -7,8 +7,13 @@
 
 #include <boost/asio.hpp>
 #include <cloysterhpc/network.h>
+#include <stdexcept>
 
 TEST_SUITE("Network setters and getters")
 {
-
+    TEST_CASE("fetchSubnetMask throws for unknown interface")
+    {
+        CHECK_THROWS_AS(Network::fetchSubnetMask("nonexistent0"),
+            std::runtime_error);
+    }
 }


### PR DESCRIPTION
## Summary
- fix unreachable return in Network::fetchSubnetMask to always throw
- add unit test ensuring fetchSubnetMask errors for unknown interface

## Testing
- `./test.sh` (fails: missing dependency build; aborted after heavy dependency build)

------
https://chatgpt.com/codex/tasks/task_e_689f4ff1b28883229531638ef689eb4c