### PR TITLE
Mark repository as read-only and redirect to opencattus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> This repository is now read-only and kept for historical reference.
+>
+> Development has continued at [VersatusHPC/opencattus](https://github.com/VersatusHPC/opencattus).
+>
+> Please use that repository for active development, issues, pull requests, and current documentation.
+
 # CloysterHPC
 
 CloysterHPC is a software that guides the user to set up


### PR DESCRIPTION
Add a short archival notice at the top of README.md and point active development to VersatusHPC/opencattus.